### PR TITLE
Sanitize CSV exports for refund and sales reports

### DIFF
--- a/adminSide/ORDERS/ManageRefund.php
+++ b/adminSide/ORDERS/ManageRefund.php
@@ -103,19 +103,28 @@
       clickedBtn.classList.add('btn-active');
     }
 
+    function sanitizeCSVCell(value) {
+      value = value.replace(/"/g, '""');
+      if (/^[=+\-@]/.test(value)) {
+        value = "'" + value;
+      }
+      return `"${value}"`;
+    }
+
     function exportRefunds() {
       const rows = Array.from(document.querySelectorAll('#refundTable tr')).filter(row => row.style.display !== 'none');
-      let csv = "Refund ID,Order ID,Customer,Reason,Date,Status\n";
+      const headers = ['Refund ID','Order ID','Customer','Reason','Date','Status'].map(sanitizeCSVCell).join(',');
+      let csv = headers + "\n";
 
       rows.forEach(row => {
         const cells = row.querySelectorAll('td');
         csv += [
-          cells[1].textContent.trim(),
-          cells[2].textContent.trim(),
-          cells[3].textContent.trim(),
-          cells[4].textContent.trim(),
-          cells[5].textContent.trim(),
-          cells[6].textContent.trim()
+          sanitizeCSVCell(cells[1].textContent.trim()),
+          sanitizeCSVCell(cells[2].textContent.trim()),
+          sanitizeCSVCell(cells[3].textContent.trim()),
+          sanitizeCSVCell(cells[4].textContent.trim()),
+          sanitizeCSVCell(cells[5].textContent.trim()),
+          sanitizeCSVCell(cells[6].textContent.trim())
         ].join(",") + "\n";
       });
 

--- a/adminSide/Reports/SalesReport.php
+++ b/adminSide/Reports/SalesReport.php
@@ -149,11 +149,19 @@
       }
     });
 
+    function sanitizeCSVCell(value) {
+      value = value.replace(/"/g, '""');
+      if (/^[=+\-@]/.test(value)) {
+        value = "'" + value;
+      }
+      return `"${value}"`;
+    }
+
     function exportTableToCSV() {
       const table = document.getElementById("salesTable");
       let csv = [];
       for (let row of table.rows) {
-        let cols = Array.from(row.cells).map(cell => `"${cell.innerText}"`);
+        let cols = Array.from(row.cells).map(cell => sanitizeCSVCell(cell.innerText.trim()));
         csv.push(cols.join(","));
       }
       const csvContent = "data:text/csv;charset=utf-8," + csv.join("\n");


### PR DESCRIPTION
## Summary
- sanitize each refund export cell to escape quotes and prevent formula injection
- wrap sales report CSV cells in sanitized quotes to avoid malicious values

## Testing
- `php -l adminSide/ORDERS/ManageRefund.php`
- `php -l adminSide/Reports/SalesReport.php`


------
https://chatgpt.com/codex/tasks/task_e_6898c91194bc8324a563889c8cf44fe9