### PR TITLE
docs: expand README and add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS Instructions
+
+- Use `rg` for searching the repository.
+- When modifying PHP files, run `php -l` on each changed file to check for syntax errors.
+- No automated test suite is available. Make a best effort to validate changes with linting.
+- Include relevant terminal or file path citations in summaries.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,48 @@
 # Cindy's Bakeshop
 
-## Project Purpose
-Cindy's Bakeshop is a simple web application for managing an online bakery. It
-includes pages for customers to browse and order products as well as an
-administrative interface for managing inventory, orders and deliveries.
+## Overview
+Cindy's Bakeshop is a lightweight PHP/MySQL application for running an online
+bakery. Customers can register, browse products, place orders, and track
+deliveries while administrators manage the catalogue and fulfilment.
 
-## Required PHP Setup
+### Features
+- Product browsing with images and descriptions
+- User registration and login
+- Cart and order submission
+- Administrative dashboard for inventory, orders and deliveries
+
+## Requirements
 - **PHP 8** or higher with the PDO MySQL extension enabled
 - **MySQL/MariaDB** server
 - A web server such as Apache/Nginx (or PHP's built-in server for testing)
 
 ## Directory Structure
-- `Database/` – SQL dump (`cindys_bakeshop.sql`) for the database
+- `Database/` – SQL dump (`cindys_bakeshop.sql`) for database schema and sample data
 - `PHP/` – reusable PHP scripts that implement database functions
-- `adminSide/` – main administrator dashboard pages
+- `adminSide/` – administrator dashboard pages
 - `user-cindysbakeshop/` – customer‑facing pages
-- `Admin Cindys/`, `UpdatedUser/`, `UpdatedUser1/` – legacy/alternate versions
+- `Admin Cindys/`, `UpdatedUser/`, `UpdatedUser1/` – legacy/alternate versions kept for reference
 
-## Importing the SQL Dump
+## Installation
 1. Create a database named `cindysdb` in your MySQL server.
-2. Import the dump using phpMyAdmin or the command line:
+2. Import the SQL dump using phpMyAdmin or the command line:
    ```sh
    mysql -u root -p cindysdb < Database/cindys_bakeshop.sql
    ```
    Adjust the credentials or database name as needed.
+3. Update `PHP/db_connect.php` with your database credentials.
 
-## PHP Backend Location
-The PHP backend lives in the `PHP/` directory. `db_connect.php` contains the
-connection settings and other files provide functions for users, orders,
-products and more. Update the credentials in that file to match your local
-setup.
-
-You can place the repository in your web server's document root and browse the
-HTML pages or start a local server with:
+## Running Locally
+Place the repository inside your web server's document root or start a local
+development server:
 ```sh
 php -S localhost:8000
 ```
+- Browse the customer-facing site at `http://localhost:8000/user-cindysbakeshop`.
+- Access the admin dashboard at `http://localhost:8000/adminSide`.
+
+## Contributing
+Pull requests are welcome. Please ensure that any modified PHP files pass
+`php -l` for syntax errors before submitting changes.
+
 


### PR DESCRIPTION
## Summary
- expand README with feature list, setup, and contribution guidelines
- add AGENTS instructions for repository searches and PHP linting

## Testing
- `php -l PHP/db_connect.php`

------
https://chatgpt.com/codex/tasks/task_e_689964c64b7083248b7f439860f14c24