### PR TITLE
Connect manage orders page to backend

### DIFF
--- a/Database/order_sample_data.sql
+++ b/Database/order_sample_data.sql
@@ -1,0 +1,14 @@
+INSERT INTO User (User_ID, Name, Email, Password, Address, Warning_Count) VALUES
+    (1, 'Mariel Balanac', 'mariel@example.com', '$2y$10$abcdefghijklmnopqrstuv', '123 Sample St', 0),
+    (2, 'Juan Dela Cruz', 'juan@example.com', '$2y$10$abcdefghijklmnopqrstuv', '456 Sample St', 0),
+    (3, 'Anna Reyes', 'anna@example.com', '$2y$10$abcdefghijklmnopqrstuv', '789 Sample St', 0);
+
+INSERT INTO `Order` (Order_ID, User_ID, Order_Date, Status) VALUES
+    (1, 1, '2025-07-01', 'Pending'),
+    (2, 2, '2025-07-02', 'Shipped'),
+    (3, 3, '2025-07-03', 'Delivered');
+
+INSERT INTO Order_Item (Order_Item_ID, Order_ID, Product_ID, Quantity, Subtotal) VALUES
+    (1, 1, 23, 1, 699.00),
+    (2, 2, 8, 1, 250.00),
+    (3, 3, 16, 1, 320.00);

--- a/PHP/export_orders_csv.php
+++ b/PHP/export_orders_csv.php
@@ -1,0 +1,32 @@
+<?php
+require_once 'db_connect.php';
+require_once 'order_functions.php';
+require_once 'order_item_functions.php';
+require_once 'user_functions.php';
+
+$orders = getAllOrders($pdo);
+
+header('Content-Type: text/csv');
+header('Content-Disposition: attachment; filename="orders.csv"');
+
+$output = fopen('php://output', 'w');
+fputcsv($output, ['Order ID', 'Customer', 'Items', 'Total', 'Status']);
+
+foreach ($orders as $order) {
+    $user = getUserById($pdo, $order['User_ID']);
+    $items = getOrderItemsByOrderId($pdo, $order['Order_ID']);
+    $itemCount = count($items);
+    $total = calculateOrderTotal($pdo, $order['Order_ID']);
+
+    fputcsv($output, [
+        sprintf('%05d', $order['Order_ID']),
+        $user['Name'] ?? 'User ' . $order['User_ID'],
+        $itemCount,
+        number_format($total ?? 0, 2, '.', ''),
+        $order['Status']
+    ]);
+}
+
+fclose($output);
+exit;
+?>

--- a/adminSide/ORDERS/ManageOrders.php
+++ b/adminSide/ORDERS/ManageOrders.php
@@ -44,7 +44,7 @@
             <input type="text" id="searchOrder" placeholder="Search Order ID" class="border rounded px-2 py-1 text-sm">
             <input type="date" class="border rounded px-2 py-1 text-sm">
             <input type="date" class="border rounded px-2 py-1 text-sm">
-            <button class="bg-gray-300 px-4 py-1 rounded text-sm">Export Orders</button>
+            <a href="../../PHP/export_orders_csv.php" class="bg-gray-300 px-4 py-1 rounded text-sm">Export Orders</a>
           </div>
           <div class="flex space-x-4 mb-2 text-sm">
             <button onclick="filterOrders('all')" class="tab-active">All</button>

--- a/adminSide/ORDERS/ManageOrders.php
+++ b/adminSide/ORDERS/ManageOrders.php
@@ -14,6 +14,13 @@
     <?php
     $activePage = 'orders';
     include '../sidebar.php';
+
+    require_once '../../PHP/db_connect.php';
+    require_once '../../PHP/order_functions.php';
+    require_once '../../PHP/order_item_functions.php';
+    require_once '../../PHP/user_functions.php';
+
+    $orders = getAllOrders($pdo);
     ?>
 
     <!-- Main Content -->
@@ -41,9 +48,9 @@
           </div>
           <div class="flex space-x-4 mb-2 text-sm">
             <button onclick="filterOrders('all')" class="tab-active">All</button>
-            <button onclick="filterOrders('to process')" class="text-blue-600">To Process</button>
+            <button onclick="filterOrders('pending')" class="text-blue-600">Pending</button>
             <button onclick="filterOrders('shipped')" class="text-blue-600">Shipped</button>
-            <button onclick="filterOrders('completed')" class="text-blue-600">Completed</button>
+            <button onclick="filterOrders('delivered')" class="text-blue-600">Delivered</button>
           </div>
           <table class="table w-full text-sm text-left">
             <thead class="border-b">
@@ -58,33 +65,27 @@
               </tr>
             </thead>
             <tbody id="orderTable">
-              <tr data-status="to process">
+            <?php foreach ($orders as $order):
+              $user = getUserById($pdo, $order['User_ID']);
+              $items = getOrderItemsByOrderId($pdo, $order['Order_ID']);
+              $itemCount = count($items);
+              $total = calculateOrderTotal($pdo, $order['Order_ID']);
+              $status = strtolower($order['Status']);
+              $statusClass = '';
+              if ($status === 'pending') { $statusClass = 'text-yellow-500'; }
+              elseif ($status === 'shipped') { $statusClass = 'text-blue-500'; }
+              elseif ($status === 'delivered') { $statusClass = 'text-green-500'; }
+            ?>
+              <tr data-status="<?= $status ?>">
                 <td><input type="checkbox"></td>
-                <td>00001</td>
-                <td>Mariel Balanac</td>
-                <td>Ensaymada Ube</td>
-                <td>₱699.00</td>
-                <td class="text-yellow-500 font-medium">To Process</td>
+                <td><?= sprintf('%05d', $order['Order_ID']); ?></td>
+                <td><?= htmlspecialchars($user['Name'] ?? 'User '.$order['User_ID']); ?></td>
+                <td><?= $itemCount; ?> item<?= $itemCount === 1 ? '' : 's'; ?></td>
+                <td>₱<?= number_format($total ?? 0, 2); ?></td>
+                <td class="<?= $statusClass ?> font-medium"><?= htmlspecialchars($order['Status']); ?></td>
                 <td class="text-blue-500 cursor-pointer">View</td>
               </tr>
-              <tr data-status="shipped">
-                <td><input type="checkbox"></td>
-                <td>00002</td>
-                <td>Juan Dela Cruz</td>
-                <td>Pandesal Box</td>
-                <td>₱250.00</td>
-                <td class="text-blue-500 font-medium">Shipped</td>
-                <td class="text-blue-500 cursor-pointer">View</td>
-              </tr>
-              <tr data-status="completed">
-                <td><input type="checkbox"></td>
-                <td>00003</td>
-                <td>Anna Reyes</td>
-                <td>Cheese Roll</td>
-                <td>₱320.00</td>
-                <td class="text-green-500 font-medium">Completed</td>
-                <td class="text-blue-500 cursor-pointer">View</td>
-              </tr>
+            <?php endforeach; ?>
             </tbody>
           </table>
         </div>

--- a/adminSide/ORDERS/ManageOrders.php
+++ b/adminSide/ORDERS/ManageOrders.php
@@ -42,8 +42,8 @@
         <div class="bg-white p-4 rounded shadow">
           <div class="flex items-center gap-4 mb-4">
             <input type="text" id="searchOrder" placeholder="Search Order ID" class="border rounded px-2 py-1 text-sm">
-            <input type="date" class="border rounded px-2 py-1 text-sm">
-            <input type="date" class="border rounded px-2 py-1 text-sm">
+            <input type="date" id="startDate" class="border rounded px-2 py-1 text-sm">
+            <input type="date" id="endDate" class="border rounded px-2 py-1 text-sm">
             <a href="../../PHP/export_orders_csv.php" class="bg-gray-300 px-4 py-1 rounded text-sm">Export Orders</a>
           </div>
           <div class="flex space-x-4 mb-2 text-sm">
@@ -57,6 +57,7 @@
               <tr>
                 <th class="py-2">✓</th>
                 <th>Order ID</th>
+                <th>Order Date</th>
                 <th>Customer</th>
                 <th>Items</th>
                 <th>Total</th>
@@ -76,9 +77,10 @@
               elseif ($status === 'shipped') { $statusClass = 'text-blue-500'; }
               elseif ($status === 'delivered') { $statusClass = 'text-green-500'; }
             ?>
-              <tr data-status="<?= $status ?>">
+              <tr data-status="<?= $status ?>" data-date="<?= htmlspecialchars($order['Order_Date']); ?>">
                 <td><input type="checkbox"></td>
                 <td><?= sprintf('%05d', $order['Order_ID']); ?></td>
+                <td><?= htmlspecialchars($order['Order_Date']); ?></td>
                 <td><?= htmlspecialchars($user['Name'] ?? 'User '.$order['User_ID']); ?></td>
                 <td><?= $itemCount; ?> item<?= $itemCount === 1 ? '' : 's'; ?></td>
                 <td>₱<?= number_format($total ?? 0, 2); ?></td>
@@ -95,17 +97,33 @@
 
   <!-- Sidebar Script -->
   <script>
+    let currentStatus = 'all';
+
     function filterOrders(status) {
+      currentStatus = status;
+      applyFilters();
+    }
+
+    function applyFilters() {
+      const start = document.getElementById('startDate').value;
+      const end = document.getElementById('endDate').value;
       const rows = document.querySelectorAll('#orderTable tr');
       rows.forEach(row => {
         const rowStatus = row.dataset.status;
-        if (status === 'all' || rowStatus === status) {
+        const rowDate = row.dataset.date;
+        const statusMatch = currentStatus === 'all' || rowStatus === currentStatus;
+        const afterStart = !start || rowDate >= start;
+        const beforeEnd = !end || rowDate <= end;
+        if (statusMatch && afterStart && beforeEnd) {
           row.style.display = '';
         } else {
           row.style.display = 'none';
         }
       });
     }
+
+    document.getElementById('startDate').addEventListener('change', applyFilters);
+    document.getElementById('endDate').addEventListener('change', applyFilters);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Hook admin Manage Orders page to database via reusable PHP functions
- Replace placeholder rows with dynamic order/user/item data and status filtering
- Add SQL sample data for users, orders, and order items

## Testing
- `php -l adminSide/ORDERS/ManageOrders.php`


------
https://chatgpt.com/codex/tasks/task_e_689be61a803c8324983c0bd2ee4eef02