### PR TITLE
Add order cancellation table and admin page backend

### DIFF
--- a/Database/cindys_bakeshop.sql
+++ b/Database/cindys_bakeshop.sql
@@ -433,3 +433,19 @@ INSERT INTO `product_ratings` (`Product_Name`, `Average_Rating`, `Total_Review`,
 ('EGG PIE CARAMEL', 4.2, 15, 'Yummy'),
 ('PASTEL DELIGHT ROUND CAKE', 3.4, 9, 'wow yummy');
 
+
+-- Table structure for table `order_cancellation`
+CREATE TABLE `order_cancellation` (
+  `Cancellation_ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Order_ID` int(11) DEFAULT NULL,
+  `User_ID` int(11) DEFAULT NULL,
+  `Reason` text DEFAULT NULL,
+  `Cancellation_Date` date DEFAULT NULL,
+  `Status` enum('Pending','Approved','Rejected') DEFAULT 'Pending',
+  PRIMARY KEY (`Cancellation_ID`),
+  KEY `Order_ID` (`Order_ID`),
+  KEY `User_ID` (`User_ID`),
+  CONSTRAINT `order_cancellation_ibfk_1` FOREIGN KEY (`Order_ID`) REFERENCES `order` (`Order_ID`),
+  CONSTRAINT `order_cancellation_ibfk_2` FOREIGN KEY (`User_ID`) REFERENCES `user` (`User_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+

--- a/Database/order_cancellations.sql
+++ b/Database/order_cancellations.sql
@@ -1,0 +1,14 @@
+-- Table structure for table `order_cancellation`
+CREATE TABLE `order_cancellation` (
+  `Cancellation_ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Order_ID` int(11) DEFAULT NULL,
+  `User_ID` int(11) DEFAULT NULL,
+  `Reason` text DEFAULT NULL,
+  `Cancellation_Date` date DEFAULT NULL,
+  `Status` enum('Pending','Approved','Rejected') DEFAULT 'Pending',
+  PRIMARY KEY (`Cancellation_ID`),
+  KEY `Order_ID` (`Order_ID`),
+  KEY `User_ID` (`User_ID`),
+  CONSTRAINT `order_cancellation_ibfk_1` FOREIGN KEY (`Order_ID`) REFERENCES `order` (`Order_ID`),
+  CONSTRAINT `order_cancellation_ibfk_2` FOREIGN KEY (`User_ID`) REFERENCES `user` (`User_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/PHP/order_cancellation_functions.php
+++ b/PHP/order_cancellation_functions.php
@@ -1,0 +1,40 @@
+<?php
+// Functions for order cancellation operations
+
+function addOrderCancellation($pdo, $orderId, $userId, $reason, $date, $status = 'Pending') {
+    $stmt = $pdo->prepare(
+        "INSERT INTO order_cancellation (Order_ID, User_ID, Reason, Cancellation_Date, Status)
+         VALUES (:order_id, :user_id, :reason, :date, :status)"
+    );
+    $stmt->execute([
+        ':order_id' => $orderId,
+        ':user_id' => $userId,
+        ':reason' => $reason,
+        ':date' => $date,
+        ':status' => $status
+    ]);
+    return $pdo->lastInsertId();
+}
+
+function getAllOrderCancellations($pdo) {
+    $stmt = $pdo->query(
+        "SELECT oc.*, u.Name AS Customer
+         FROM order_cancellation oc
+         LEFT JOIN User u ON oc.User_ID = u.User_ID"
+    );
+    return $stmt->fetchAll();
+}
+
+function updateOrderCancellationStatus($pdo, $cancellationId, $status) {
+    $stmt = $pdo->prepare(
+        "UPDATE order_cancellation
+         SET Status = :status
+         WHERE Cancellation_ID = :id"
+    );
+    $stmt->execute([
+        ':status' => $status,
+        ':id' => $cancellationId
+    ]);
+    return $stmt->rowCount();
+}
+?>


### PR DESCRIPTION
## Summary
- create order_cancellation table and separate SQL script
- add PHP functions to manage order cancellations
- wire up ManageCancel admin page to display and update cancellation requests

## Testing
- `php -l adminSide/ORDERS/ManageCancel.php`
- `php -l PHP/order_cancellation_functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689c1028adf083249d4e780c338dd202