### PR TITLE
Add refund management backend

### DIFF
--- a/Database/cindys_bakeshop.sql
+++ b/Database/cindys_bakeshop.sql
@@ -449,3 +449,18 @@ CREATE TABLE `order_cancellation` (
   CONSTRAINT `order_cancellation_ibfk_2` FOREIGN KEY (`User_ID`) REFERENCES `user` (`User_ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+
+-- Table structure for table `refund`
+CREATE TABLE `refund` (
+  `Refund_ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Order_ID` int(11) DEFAULT NULL,
+  `User_ID` int(11) DEFAULT NULL,
+  `Reason` text DEFAULT NULL,
+  `Refund_Date` date DEFAULT NULL,
+  `Status` enum('Pending','Approved','Rejected') DEFAULT 'Pending',
+  PRIMARY KEY (`Refund_ID`),
+  KEY `Order_ID` (`Order_ID`),
+  KEY `User_ID` (`User_ID`),
+  CONSTRAINT `refund_ibfk_1` FOREIGN KEY (`Order_ID`) REFERENCES `order` (`Order_ID`),
+  CONSTRAINT `refund_ibfk_2` FOREIGN KEY (`User_ID`) REFERENCES `user` (`User_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/Database/refunds.sql
+++ b/Database/refunds.sql
@@ -1,0 +1,14 @@
+-- Table structure for table `refund`
+CREATE TABLE `refund` (
+  `Refund_ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Order_ID` int(11) DEFAULT NULL,
+  `User_ID` int(11) DEFAULT NULL,
+  `Reason` text DEFAULT NULL,
+  `Refund_Date` date DEFAULT NULL,
+  `Status` enum('Pending','Approved','Rejected') DEFAULT 'Pending',
+  PRIMARY KEY (`Refund_ID`),
+  KEY `Order_ID` (`Order_ID`),
+  KEY `User_ID` (`User_ID`),
+  CONSTRAINT `refund_ibfk_1` FOREIGN KEY (`Order_ID`) REFERENCES `order` (`Order_ID`),
+  CONSTRAINT `refund_ibfk_2` FOREIGN KEY (`User_ID`) REFERENCES `user` (`User_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/PHP/refund_functions.php
+++ b/PHP/refund_functions.php
@@ -1,0 +1,40 @@
+<?php
+// Functions for refund operations
+
+function addRefund($pdo, $orderId, $userId, $reason, $date, $status = 'Pending') {
+    $stmt = $pdo->prepare(
+        "INSERT INTO refund (Order_ID, User_ID, Reason, Refund_Date, Status)
+         VALUES (:order_id, :user_id, :reason, :date, :status)"
+    );
+    $stmt->execute([
+        ':order_id' => $orderId,
+        ':user_id' => $userId,
+        ':reason' => $reason,
+        ':date' => $date,
+        ':status' => $status
+    ]);
+    return $pdo->lastInsertId();
+}
+
+function getAllRefunds($pdo) {
+    $stmt = $pdo->query(
+        "SELECT r.*, u.Name AS Customer
+         FROM refund r
+         LEFT JOIN User u ON r.User_ID = u.User_ID"
+    );
+    return $stmt->fetchAll();
+}
+
+function updateRefundStatus($pdo, $refundId, $status) {
+    $stmt = $pdo->prepare(
+        "UPDATE refund
+         SET Status = :status
+         WHERE Refund_ID = :id"
+    );
+    $stmt->execute([
+        ':status' => $status,
+        ':id' => $refundId
+    ]);
+    return $stmt->rowCount();
+}
+?>


### PR DESCRIPTION
## Summary
- add `refund` table to main SQL dump and standalone script
- implement PHP functions to insert, list, and update refunds
- connect admin refund management page to database with approve/reject, search, and export features

## Testing
- `php -l PHP/refund_functions.php`
- `php -l adminSide/ORDERS/ManageRefund.php`


------
https://chatgpt.com/codex/tasks/task_e_689c13fb0e4c8324b00921a98bd0f8de