### PR TITLE
Add product edit/delete endpoints and admin UI

### DIFF
--- a/PHP/product_functions.php
+++ b/PHP/product_functions.php
@@ -129,4 +129,41 @@ function countProducts($pdo) {
     $stmt = $pdo->query("SELECT COUNT(*) FROM Product");
     return $stmt->fetchColumn();
 }
+
+// --- API Endpoints -------------------------------------------------------
+// Allows this file to handle update, delete, and list operations via AJAX.
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
+    require_once __DIR__ . '/db_connect.php';
+    header('Content-Type: application/json');
+
+    switch ($_POST['action']) {
+        case 'update':
+            $id = $_POST['product_id'] ?? 0;
+            $name = $_POST['name'] ?? '';
+            $description = $_POST['description'] ?? '';
+            $price = $_POST['price'] ?? 0;
+            $stock = $_POST['stock_quantity'] ?? 0;
+            $category = $_POST['category'] ?? '';
+            $imageFile = $_FILES['image'] ?? null;
+            $success = updateProductById($pdo, $id, $name, $description, $price, $stock, $category, $imageFile) > 0;
+            echo json_encode(['success' => $success]);
+            break;
+
+        case 'delete':
+            $id = $_POST['product_id'] ?? 0;
+            $success = deleteProductById($pdo, $id) > 0;
+            echo json_encode(['success' => $success]);
+            break;
+
+        case 'getAll':
+            $products = getAllProducts($pdo);
+            echo json_encode($products);
+            break;
+
+        default:
+            echo json_encode(['success' => false, 'message' => 'Invalid action']);
+            break;
+    }
+    exit;
+}
 ?>

--- a/adminSide/products/ManageProduct.php
+++ b/adminSide/products/ManageProduct.php
@@ -36,24 +36,63 @@
   </div>
 </main>
 
+<!-- Edit Modal -->
+<div id="editModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+  <form id="editForm" class="bg-white p-6 rounded space-y-2" enctype="multipart/form-data">
+    <input type="hidden" name="product_id" id="editProductId">
+    <div>
+      <label class="block font-semibold">Name</label>
+      <input type="text" name="name" id="editName" class="w-full border rounded px-2 py-1">
+    </div>
+    <div>
+      <label class="block font-semibold">Category</label>
+      <select name="category" id="editCategory" class="w-full border rounded px-2 py-1">
+        <option value="Bread">Bread</option>
+        <option value="Cake">Cake</option>
+        <option value="Pastry">Pastry</option>
+      </select>
+    </div>
+    <div>
+      <label class="block font-semibold">Description</label>
+      <textarea name="description" id="editDescription" rows="3" class="w-full border rounded px-2 py-1"></textarea>
+    </div>
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label class="block font-semibold">Price</label>
+        <input type="number" name="price" id="editPrice" class="w-full border rounded px-2 py-1">
+      </div>
+      <div>
+        <label class="block font-semibold">Stock</label>
+        <input type="number" name="stock_quantity" id="editStock" class="w-full border rounded px-2 py-1">
+      </div>
+    </div>
+    <div>
+      <label class="block font-semibold">Image</label>
+      <input type="file" name="image" id="editImage" class="w-full border rounded px-2 py-1">
+    </div>
+    <div class="flex justify-end gap-2 pt-2">
+      <button type="button" onclick="closeEditModal()" class="px-4 py-2 bg-gray-300 rounded">Cancel</button>
+      <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Save</button>
+    </div>
+  </form>
+</div>
+
 <script>
-  const products = <?php
+  let products = <?php
     echo json_encode(array_map(function($p) {
         return [
             'id' => $p['Product_ID'],
             'name' => $p['Name'],
-            'price' => '₱' . $p['Price'],
+            'price' => $p['Price'],
             'category' => $p['Category'],
             'image' => $p['Image_Path'] ? 'uploads/' . $p['Image_Path'] : "../images/cindy's logo.png",
-            'stock' => $p['Stock_Quantity']
+            'stock' => $p['Stock_Quantity'],
+            'description' => $p['Description']
         ];
     }, $products));
   ?>;
 
-
-
-  const itemsPerPage = 24
-;
+  const itemsPerPage = 24;
   let currentPage = 1;
 
   function displayProducts() {
@@ -78,7 +117,7 @@
       grid.innerHTML += `
         <div class="product-card">
           <img src="${p.image}" alt="${p.name}" loading="lazy">
-          <div class="price">${p.price}</div>
+          <div class="price">₱${p.price}</div>
           <div class="stock ${stockClass}">Stock: ${p.stock}</div>
           <div style="font-weight: bold;">${p.name}</div>
           <button onclick="editProduct(${p.id})">Edit</button>
@@ -106,15 +145,78 @@
   }
 
   function editProduct(id) {
-    alert("Edit Product #" + id);
+    const product = products.find(p => p.id === id);
+    if (!product) return;
+
+    document.getElementById('editProductId').value = product.id;
+    document.getElementById('editName').value = product.name;
+    document.getElementById('editCategory').value = product.category;
+    document.getElementById('editDescription').value = product.description;
+    document.getElementById('editPrice').value = product.price;
+    document.getElementById('editStock').value = product.stock;
+    document.getElementById('editImage').value = '';
+    document.getElementById('editModal').classList.remove('hidden');
   }
 
+  function closeEditModal() {
+    document.getElementById('editForm').reset();
+    document.getElementById('editModal').classList.add('hidden');
+  }
+
+  document.getElementById('editForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    formData.append('action', 'update');
+
+    fetch('../../PHP/product_functions.php', {
+      method: 'POST',
+      body: formData
+    })
+    .then(r => r.json())
+    .then(data => {
+      if (data.success) {
+        closeEditModal();
+        reloadProducts();
+      } else {
+        alert('Update failed');
+      }
+    });
+  });
+
   function deleteProduct(id) {
-    const confirmDelete = confirm("Are you sure you want to delete product #" + id + "?");
-    if (confirmDelete) {
-      alert("Deleted Product #" + id);
-    }
-}
+    if (!confirm(`Are you sure you want to delete product #${id}?`)) return;
+    const fd = new FormData();
+    fd.append('action', 'delete');
+    fd.append('product_id', id);
+    fetch('../../PHP/product_functions.php', { method: 'POST', body: fd })
+      .then(r => r.json())
+      .then(data => {
+        if (data.success) {
+          reloadProducts();
+        } else {
+          alert('Deletion failed');
+        }
+      });
+  }
+
+  function reloadProducts() {
+    const fd = new FormData();
+    fd.append('action', 'getAll');
+    fetch('../../PHP/product_functions.php', { method: 'POST', body: fd })
+      .then(r => r.json())
+      .then(data => {
+        products = data.map(p => ({
+          id: p.Product_ID,
+          name: p.Name,
+          price: p.Price,
+          category: p.Category,
+          image: p.Image_Path ? 'uploads/' + p.Image_Path : "../images/cindy's logo.png",
+          stock: p.Stock_Quantity,
+          description: p.Description
+        }));
+        displayProducts();
+      });
+  }
 
   document.getElementById("search").addEventListener("input", () => {
     currentPage = 1;


### PR DESCRIPTION
## Summary
- expose product update, delete, and list endpoints in `product_functions.php`
- add modal edit form and AJAX calls in product manager to update/delete products and refresh list

## Testing
- `php -l PHP/product_functions.php`
- `php -l adminSide/products/ManageProduct.php`


------
https://chatgpt.com/codex/tasks/task_e_689c19b4cc788324880d3f68fc20abeb