### PR TITLE
Add CSRF tokens and input filtering to admin forms

### DIFF
--- a/adminSide/products/AddNewProduct.php
+++ b/adminSide/products/AddNewProduct.php
@@ -1,3 +1,40 @@
+<?php
+session_start();
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+require '../../PHP/db_connect.php';
+require '../../PHP/product_functions.php';
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = filter_input(INPUT_POST, 'csrf_token', FILTER_SANITIZE_SPECIAL_CHARS);
+    if (!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+        $message = 'Invalid CSRF token.';
+        error_log('CSRF token mismatch in AddNewProduct.php');
+    } else {
+        $name = filter_input(INPUT_POST, 'productName', FILTER_SANITIZE_SPECIAL_CHARS) ?? '';
+        $category = filter_input(INPUT_POST, 'category', FILTER_SANITIZE_SPECIAL_CHARS) ?? '';
+        $description = filter_input(INPUT_POST, 'description', FILTER_SANITIZE_SPECIAL_CHARS) ?? '';
+        $price = filter_input(INPUT_POST, 'price', FILTER_VALIDATE_FLOAT);
+        $price = $price !== false ? $price : 0;
+        $quantity = filter_input(INPUT_POST, 'quantity', FILTER_VALIDATE_INT);
+        $quantity = $quantity !== false ? $quantity : 0;
+        $imageFile = $_FILES['image'] ?? null;
+
+        if ($pdo) {
+            addProduct($pdo, $name, $description, $price, $quantity, $category, $imageFile);
+            $message = 'Product added successfully.';
+        } else {
+            $message = 'Database connection failed.';
+            error_log('Database connection failed in AddNewProduct.php');
+        }
+    }
+}
+
+$activePage = 'products';
+include '../sidebar.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,29 +46,7 @@
   <body>
     <div class="flex h-screen overflow-hidden">
       <?php
-      require '../../PHP/db_connect.php';
-      require '../../PHP/product_functions.php';
-
-      $message = '';
-      if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-          $name = $_POST['productName'] ?? '';
-          $category = $_POST['category'] ?? '';
-          $description = $_POST['description'] ?? '';
-          $price = $_POST['price'] ?? 0;
-          $quantity = $_POST['quantity'] ?? 0;
-          $imageFile = $_FILES['image'] ?? null;
-
-          if ($pdo) {
-              addProduct($pdo, $name, $description, $price, $quantity, $category, $imageFile);
-              $message = 'Product added successfully.';
-          } else {
-              $message = 'Database connection failed.';
-              error_log('Database connection failed in AddNewProduct.php');
-          }
-      }
-
-      $activePage = 'products';
-      include '../sidebar.php';
+      // PHP logic above
       ?>
       <main class="flex-1 overflow-y-auto">
       <div class="header-bar">
@@ -47,6 +62,7 @@
           <a href="ManageProduct.php" class="text-blue-600 hover:underline">&larr; Back to Products</a>
           <?php if ($message) { echo '<p class="text-green-600">' . htmlspecialchars($message) . '</p>'; } ?>
           <form class="mt-4 space-y-4" method="POST" enctype="multipart/form-data">
+          <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
           <div>
             <label for="productName" class="block font-semibold">Product Name</label>
             <input type="text" id="productName" name="productName" class="w-full border rounded px-2 py-1">


### PR DESCRIPTION
## Summary
- Sanitize and validate form input with `filter_input`
- Add CSRF protection by generating session tokens and verifying submissions
- Embed tokens in product and cancellation management forms

## Testing
- `php -l adminSide/products/AddNewProduct.php`
- `php -l adminSide/ORDERS/ManageCancel.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5b5e903a4832498aa642c1c7fcf3b