### PR TITLE
Store captured face images on signup

### DIFF
--- a/Database/add_user_face_image_path_column.sql
+++ b/Database/add_user_face_image_path_column.sql
@@ -1,0 +1,3 @@
+-- Adds Face_Image_Path column to User table if it does not already exist
+ALTER TABLE User
+    ADD COLUMN IF NOT EXISTS Face_Image_Path VARCHAR(255) DEFAULT NULL AFTER Warning_Count;

--- a/PHP/register_user.php
+++ b/PHP/register_user.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/db_connect.php';
+require_once __DIR__ . '/user_functions.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+
+if (!$input) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid JSON']);
+    exit;
+}
+
+$name = $input['fullName'] ?? '';
+$email = $input['email'] ?? '';
+$password = $input['password'] ?? '';
+$faceImage = $input['faceImage'] ?? '';
+
+if (!$name || !$email || !$password || !$faceImage) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing required fields']);
+    exit;
+}
+
+$parts = explode(',', $faceImage);
+if (count($parts) < 2) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid image data']);
+    exit;
+}
+
+$imageData = base64_decode($parts[1]);
+$facesDir = __DIR__ . '/../user_faces';
+if (!is_dir($facesDir)) {
+    mkdir($facesDir, 0777, true);
+}
+$filename = uniqid('face_', true) . '.png';
+$filepath = $facesDir . '/' . $filename;
+file_put_contents($filepath, $imageData);
+$relativePath = 'user_faces/' . $filename;
+
+try {
+    $userId = addUser($pdo, $name, $email, $password, '', 0, $relativePath);
+    echo json_encode(['success' => true, 'userId' => $userId, 'imagePath' => $relativePath]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to register user']);
+}
+?>

--- a/PHP/user_functions.php
+++ b/PHP/user_functions.php
@@ -4,22 +4,23 @@
         return $stmt->fetchAll();
     }
 
-    function addUser($pdo, $name, $email, $password, $address, $warning_count = 0) {
+function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $face_image_path = null) {
         // Hash the password for security
         $hashed_password = password_hash($password, PASSWORD_DEFAULT);
 
         // Prepare SQL query
-        $stmt = $pdo->prepare("INSERT INTO User (Name, Email, Password, Address, Warning_Count) 
-                            VALUES (:name, :email, :password, :address, :warning_count)");
+    $stmt = $pdo->prepare("INSERT INTO User (Name, Email, Password, Address, Warning_Count, Face_Image_Path)
+                            VALUES (:name, :email, :password, :address, :warning_count, :face_image_path)");
 
         // Execute with data
         $stmt->execute([
             ':name' => $name,
             ':email' => $email,
-            ':password' => $hashed_password,
-            ':address' => $address,
-            ':warning_count' => $warning_count
-        ]);
+        ':password' => $hashed_password,
+        ':address' => $address,
+        ':warning_count' => $warning_count,
+        ':face_image_path' => $face_image_path
+    ]);
 
         return $pdo->lastInsertId(); // returns the new User_ID
     }

--- a/userSide/LOGIN_SIGNUP/signup.html
+++ b/userSide/LOGIN_SIGNUP/signup.html
@@ -210,7 +210,11 @@
 
       try {
         await createUserWithEmailAndPassword(auth, email, pw);
-        // TODO: Save additional profile data (fullName, username, faceImage) to Firestore
+        await fetch('../../PHP/register_user.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fullName, email, password: pw, faceImage })
+        });
         passwordMsg.textContent = "";
         alert("Signup successful! Redirecting to login page...");
         window.location.href = "../LOGIN_SIGNUP/user_login.html";


### PR DESCRIPTION
## Summary
- allow signup to post captured face data to the server and database
- store uploaded face images and record their path in the User table
- add SQL migration script for `Face_Image_Path` column and image storage folder

## Testing
- `php -l PHP/user_functions.php`
- `php -l PHP/register_user.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6add355d08324ae8b8c8b4f8bf737