### PR TITLE
Add admin database reset page

### DIFF
--- a/adminSide/reset_database.php
+++ b/adminSide/reset_database.php
@@ -1,0 +1,52 @@
+<?php
+require_once '../PHP/db_connect.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $sqlFile = __DIR__ . '/../Database/cindys_bakeshop.sql';
+    if (file_exists($sqlFile)) {
+        $sql = file_get_contents($sqlFile);
+        try {
+            $pdo->exec('SET FOREIGN_KEY_CHECKS = 0;');
+            $statements = array_filter(array_map('trim', preg_split('/;\s*[\r\n]+/', $sql)));
+            foreach ($statements as $statement) {
+                if ($statement !== '') {
+                    $pdo->exec($statement);
+                }
+            }
+            $pdo->exec('SET FOREIGN_KEY_CHECKS = 1;');
+            $message = 'Database reset successfully.';
+        } catch (PDOException $e) {
+            $message = 'Error resetting database: ' . $e->getMessage();
+        }
+    } else {
+        $message = 'SQL file not found.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reset Database</title>
+    <link rel="stylesheet" href="css/admin.css">
+</head>
+<body class="dashboard-page">
+<div class="flex min-h-screen">
+<?php
+$activePage = 'reset';
+include 'sidebar.php';
+?>
+<main class="flex-1 p-6">
+    <h1 class="text-2xl font-bold mb-4">Reset Database</h1>
+    <?php if ($message): ?>
+        <p class="mb-4"><?php echo htmlspecialchars($message); ?></p>
+    <?php endif; ?>
+    <form method="post" onsubmit="return confirm('Are you sure you want to reset the database?');">
+        <button type="submit" class="bg-red-600 text-white px-4 py-2 rounded">Reset Database</button>
+    </form>
+</main>
+</div>
+</body>
+</html>

--- a/adminSide/sidebar.php
+++ b/adminSide/sidebar.php
@@ -37,6 +37,7 @@ $activePage = $activePage ?? '';
         <a href="../Reports/InventoryReport.php" class="block p-2 hover:bg-gray-100 rounded">Inventory Report</a>
       </div>
     </div>
+    <a href="../reset_database.php" class="flex items-center gap-2 p-2 rounded <?php echo $activePage === 'reset' ? 'bg-gray-200 font-semibold' : 'sidebar-link'; ?>">🗑️ Reset Database</a>
     </nav>
 </aside>
 


### PR DESCRIPTION
## Summary
- Add `reset_database.php` admin page to rebuild the SQL schema from the included dump
- Link the reset utility in the admin sidebar for easy access

## Testing
- `php -l adminSide/reset_database.php`
- `php -l adminSide/sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0902f8483249b0e520a13cb9697