### PR TITLE
Validate Firebase config and surface missing vars

### DIFF
--- a/PHP/firebase_config.php
+++ b/PHP/firebase_config.php
@@ -24,4 +24,18 @@ $config = [
     'measurementId' => getenv('FIREBASE_MEASUREMENT_ID'),
 ];
 
+// Ensure all configuration values are present
+$missing = array_keys(array_filter($config, function ($value) {
+    return $value === false || $value === null || $value === '';
+}));
+
+if (!empty($missing)) {
+    http_response_code(500);
+    echo json_encode([
+        'error' => 'Firebase configuration incomplete',
+        'missing' => $missing,
+    ]);
+    exit;
+}
+
 echo json_encode($config);


### PR DESCRIPTION
## Summary
- Validate Firebase environment variables before serving the configuration
- Return a descriptive error when any required Firebase variable is missing

## Testing
- `php -l PHP/firebase_config.php`
- `FIREBASE_API_KEY=testKey FIREBASE_AUTH_DOMAIN=test.firebaseapp.com FIREBASE_PROJECT_ID=test-project FIREBASE_STORAGE_BUCKET=test.appspot.com FIREBASE_MESSAGING_SENDER_ID=1234567890 FIREBASE_APP_ID=1:1234567890:web:abcdef FIREBASE_MEASUREMENT_ID=G-ABCDEF php PHP/firebase_config.php`
- `php PHP/firebase_config.php`

------
https://chatgpt.com/codex/tasks/task_e_68a709350bc083248dc7d6f113a67538