### PR TITLE
Convert settings page to PHP

### DIFF
--- a/Database/add_user_settings_columns.sql
+++ b/Database/add_user_settings_columns.sql
@@ -1,0 +1,7 @@
+-- Adds settings columns to User table if they do not already exist
+ALTER TABLE User
+    ADD COLUMN IF NOT EXISTS Language VARCHAR(50) DEFAULT 'English' AFTER Address,
+    ADD COLUMN IF NOT EXISTS Theme VARCHAR(20) DEFAULT 'Light' AFTER Language,
+    ADD COLUMN IF NOT EXISTS Notify_Order_Status TINYINT(1) DEFAULT 0 AFTER Theme,
+    ADD COLUMN IF NOT EXISTS Notify_Promotions TINYINT(1) DEFAULT 0 AFTER Notify_Order_Status,
+    ADD COLUMN IF NOT EXISTS Notify_Feedback TINYINT(1) DEFAULT 0 AFTER Notify_Promotions;

--- a/Database/cindys_bakeshop.sql
+++ b/Database/cindys_bakeshop.sql
@@ -177,7 +177,13 @@ CREATE TABLE `user` (
   `Email` varchar(100) DEFAULT NULL,
   `Password` varchar(255) DEFAULT NULL,
   `Address` text DEFAULT NULL,
-  `Warning_Count` int(11) DEFAULT 0
+  `Language` varchar(50) DEFAULT 'English',
+  `Theme` varchar(20) DEFAULT 'Light',
+  `Notify_Order_Status` tinyint(1) DEFAULT 0,
+  `Notify_Promotions` tinyint(1) DEFAULT 0,
+  `Notify_Feedback` tinyint(1) DEFAULT 0,
+  `Warning_Count` int(11) DEFAULT 0,
+  `Face_Image_Path` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -304,7 +304,7 @@
         <div class="dropdown-content" id="profileDropdown">
           <a href="../PROFILE/EditProfile.html">Edit Profile</a>
           <a href="../PURCHASES/MyPurchase.html">My Purchases</a>
-          <a href="../PROFILE/Settings.html">Settings</a>
+          <a href="../PROFILE/Settings.php">Settings</a>
         </div>
       </div>
       <a href="../HOME PAGING/HOME.HTML"><i class="fas fa-sign-out-alt"></i> Logout</a>

--- a/userSide/HOME PAGING/MENU.html
+++ b/userSide/HOME PAGING/MENU.html
@@ -246,7 +246,7 @@
         <div class="dropdown-content" id="profileDropdown">
           <a href="../PROFILE/EditProfile.html">Edit Profile</a>
           <a href="../PURCHASES/MyPurchase.html">My Purchases</a>
-          <a href="../PROFILE/Settings.html">Settings</a>
+          <a href="../PROFILE/Settings.php">Settings</a>
         </div>
       </div>
       <a href="../HOME PAGING/HOME.HTML"><i class="fas fa-sign-out-alt"></i> Logout</a>

--- a/userSide/PRODUCT/MENU.html
+++ b/userSide/PRODUCT/MENU.html
@@ -291,7 +291,7 @@
         <div class="dropdown-content" id="profileDropdown">
           <a href="../PROFILE/EditProfile.html">Edit Profile</a>
           <a href="../PURCHASES/MyPurchase.html">My Purchases</a>
-          <a href="../PROFILE/Settings.html">Settings</a>
+          <a href="../PROFILE/Settings.php">Settings</a>
         </div>
       </div>
        <a href="../LOGIN_SIGNUP/logout.html">Logout</a>

--- a/userSide/PROFILE/EditProfile.html
+++ b/userSide/PROFILE/EditProfile.html
@@ -190,7 +190,7 @@
         <div class="dropdown-content" id="profileDropdown">
           <a href="../PROFILE/EditProfile.html">Edit Profile</a>
           <a href="../PURCHASES/MyPurchase.html">My Purchases</a>
-          <a href="../PROFILE/Settings.html">Settings</a>
+          <a href="../PROFILE/Settings.php">Settings</a>
         </div>
       </div>
       <a href="../HOME PAGING/HOME.HTML"><i class="fas fa-sign-out-alt"></i> Logout</a>

--- a/userSide/PROFILE/Settings.php
+++ b/userSide/PROFILE/Settings.php
@@ -1,3 +1,58 @@
+<?php
+session_start();
+require_once '../../PHP/db_connect.php';
+require_once '../../PHP/user_functions.php';
+
+$userId = $_SESSION['user_id'] ?? null;
+$message = '';
+
+// Default settings
+$userSettings = [
+    'language' => 'English',
+    'theme' => 'Light',
+    'notify_order' => 0,
+    'notify_promotions' => 0,
+    'notify_feedback' => 0,
+];
+
+if ($userId) {
+    $user = getUserById($pdo, $userId);
+    if ($user) {
+        $userSettings['language'] = $user['Language'] ?? 'English';
+        $userSettings['theme'] = $user['Theme'] ?? 'Light';
+        $userSettings['notify_order'] = $user['Notify_Order_Status'] ?? 0;
+        $userSettings['notify_promotions'] = $user['Notify_Promotions'] ?? 0;
+        $userSettings['notify_feedback'] = $user['Notify_Feedback'] ?? 0;
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $userId) {
+    $userSettings['language'] = $_POST['language'] ?? 'English';
+    $userSettings['theme'] = $_POST['theme'] ?? 'Light';
+    $userSettings['notify_order'] = isset($_POST['notify_order']) ? 1 : 0;
+    $userSettings['notify_promotions'] = isset($_POST['notify_promotions']) ? 1 : 0;
+    $userSettings['notify_feedback'] = isset($_POST['notify_feedback']) ? 1 : 0;
+
+    try {
+        $stmt = $pdo->prepare("UPDATE User SET Language = :language, Theme = :theme, Notify_Order_Status = :notify_order, Notify_Promotions = :notify_promotions, Notify_Feedback = :notify_feedback WHERE User_ID = :user_id");
+        $stmt->execute([
+            ':language' => $userSettings['language'],
+            ':theme' => $userSettings['theme'],
+            ':notify_order' => $userSettings['notify_order'],
+            ':notify_promotions' => $userSettings['notify_promotions'],
+            ':notify_feedback' => $userSettings['notify_feedback'],
+            ':user_id' => $userId
+        ]);
+
+        if (!empty($_POST['newPassword']) && ($_POST['newPassword'] === ($_POST['confirmNewPassword'] ?? ''))) {
+            updateUserPasswordById($pdo, $userId, $_POST['newPassword']);
+        }
+        $message = 'Settings updated successfully.';
+    } catch (Exception $e) {
+        $message = 'Failed to update settings.';
+    }
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -85,7 +140,7 @@
       display: block;
       font-weight: bold;
     }
-    
+
 
    .back-btn {
       display: inline-block;
@@ -124,14 +179,13 @@
     }
 
     .settings-section h3 {
-      margin-bottom: 12px;
-      color: red;
-      font-size: 18px;
+      margin-bottom: 15px;
+      color: #555;
     }
 
     .settings-section label {
       display: block;
-      margin-bottom: 6px;
+      margin-bottom: 8px;
       font-weight: bold;
     }
 
@@ -168,6 +222,12 @@
       color: white;
     }
 
+    .message {
+      text-align: center;
+      font-weight: bold;
+      margin-bottom: 20px;
+    }
+
     @media screen and (max-width: 600px) {
       .container {
         padding: 20px;
@@ -193,52 +253,56 @@
         <div class="dropdown-content" id="profileDropdown">
           <a href="../PROFILE/EditProfile.html">Edit Profile</a>
           <a href="../PURCHASES/MyPurchase.html">My Purchases</a>
-          <a href="../PROFILE/Settings.html">Settings</a>
+          <a href="../PROFILE/Settings.php">Settings</a>
         </div>
       </div>
       <a href="../HOME PAGING/HOME.HTML"><i class="fas fa-sign-out-alt"></i> Logout</a>
     </div>
   </header>
- 
+
 
   <div class="container">
     <h2>User Settings</h2>
-
+    <?php if (!empty($message)): ?>
+      <p class="message"><?php echo htmlspecialchars($message); ?></p>
+    <?php endif; ?>
+    <form method="POST" action="">
     <div class="settings-section">
       <h3>Account Preferences</h3>
       <label for="language">Language</label>
-      <select id="language">
-        <option>English</option>
-        <option>Tagalog</option>
+      <select id="language" name="language">
+        <option value="English" <?php echo $userSettings['language'] === 'English' ? 'selected' : ''; ?>>English</option>
+        <option value="Tagalog" <?php echo $userSettings['language'] === 'Tagalog' ? 'selected' : ''; ?>>Tagalog</option>
       </select>
 
       <label for="theme">Theme</label>
-      <select id="theme">
-        <option>Light</option>
-        <option>Dark</option>
+      <select id="theme" name="theme">
+        <option value="Light" <?php echo $userSettings['theme'] === 'Light' ? 'selected' : ''; ?>>Light</option>
+        <option value="Dark" <?php echo $userSettings['theme'] === 'Dark' ? 'selected' : ''; ?>>Dark</option>
       </select>
     </div>
 
     <div class="settings-section">
       <h3>Notification Settings</h3>
-      <label><input type="checkbox"> Order Status Updates</label>
-      <label><input type="checkbox"> Promotions & Discounts</label>
-      <label><input type="checkbox"> Feedback Reminders</label>
+      <label><input type="checkbox" name="notify_order" <?php echo $userSettings['notify_order'] ? 'checked' : ''; ?>> Order Status Updates</label>
+      <label><input type="checkbox" name="notify_promotions" <?php echo $userSettings['notify_promotions'] ? 'checked' : ''; ?>> Promotions & Discounts</label>
+      <label><input type="checkbox" name="notify_feedback" <?php echo $userSettings['notify_feedback'] ? 'checked' : ''; ?>> Feedback Reminders</label>
     </div>
 
     <div class="settings-section">
       <h3>Security</h3>
       <label for="currentPassword">Current Password</label>
-      <input type="password" id="currentPassword">
+      <input type="password" id="currentPassword" name="currentPassword">
 
       <label for="newPassword">New Password</label>
-      <input type="password" id="newPassword">
+      <input type="password" id="newPassword" name="newPassword">
 
       <label for="confirmNewPassword">Confirm New Password</label>
-      <input type="password" id="confirmNewPassword">
+      <input type="password" id="confirmNewPassword" name="confirmNewPassword">
     </div>
 
-    <button class="save-btn" onclick="alert('Settings saved!')">Save Settings</button>
+    <button class="save-btn" type="submit">Save Settings</button>
+    </form>
   </div>
 
   <script>

--- a/userSide/PURCHASES/MyPurchase.html
+++ b/userSide/PURCHASES/MyPurchase.html
@@ -269,7 +269,7 @@
         <div class="dropdown-content" id="profileDropdown">
           <a href="../PROFILE/EditProfile.html">Edit Profile</a>
           <a href="../PURCHASES/MyPurchase.html">My Purchases</a>
-          <a href="../PROFILE/Settings.html">Settings</a>
+          <a href="../PROFILE/Settings.php">Settings</a>
         </div>
       </div>
       <a href="../HOME PAGING/HOME.HTML"><i class="fas fa-sign-out-alt"></i> Logout</a>


### PR DESCRIPTION
## Summary
- Convert user profile settings page from static HTML to PHP
- Load and update settings via PDO with success/failure messaging
- Update navigation links to reference new settings PHP page
- Add user settings columns to the database schema with migration script

## Testing
- `php -l userSide/PROFILE/Settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7c0173118832485e97ecf81737a36