### PR TITLE
feat: initialize Firebase on all user pages

### DIFF
--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -555,5 +555,6 @@
 
     window.addEventListener("DOMContentLoaded", loadCart);
   </script>
+  <script type="module" src="../firebase-init.js"></script>
 </body>
 </html>

--- a/userSide/FAVORITE/my favorite.html
+++ b/userSide/FAVORITE/my favorite.html
@@ -167,6 +167,7 @@
         noFav.style.display = 'block';
       });
   </script>
+  <script type="module" src="../firebase-init.js"></script>
 
 </body>
 </html>

--- a/userSide/HOME PAGING/MENU.html
+++ b/userSide/HOME PAGING/MENU.html
@@ -437,6 +437,7 @@
     </div>
   </footer>
   </section>
+  <script type="module" src="../firebase-init.js"></script>
 
   <script>
     function toggleDropdown() {

--- a/userSide/HOME PAGING/about.html
+++ b/userSide/HOME PAGING/about.html
@@ -208,6 +208,7 @@ header {
       <a href="#">Email: chadhbasjkb@com</a>
     </div>
   </footer>
+  <script type="module" src="../firebase-init.js"></script>
 
 </body>
 </html>

--- a/userSide/INVOICE/orderDetails.html
+++ b/userSide/INVOICE/orderDetails.html
@@ -148,5 +148,6 @@
     html2pdf().set(opt).from(element).save();
   });
 </script>
+  <script type="module" src="../firebase-init.js"></script>
 </body>
 </html>

--- a/userSide/LOGIN_SIGNUP/logout.html
+++ b/userSide/LOGIN_SIGNUP/logout.html
@@ -13,7 +13,7 @@
 
     <script type="module">
       import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-      import { getAuth, signOut } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+      import { getAuth, signOut, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
       async function loadFirebase() {
         const response = await fetch('../../PHP/firebase_config.php', { credentials: 'same-origin' });
@@ -22,6 +22,16 @@
         }
         const app = initializeApp(await response.json());
         const auth = getAuth(app);
+
+        window.auth = auth;
+        window.getAuth = getAuth;
+        onAuthStateChanged(auth, user => {
+          if (user) {
+            console.log('Logged in as:', user.email);
+          } else {
+            console.log('Not logged in');
+          }
+        });
 
         signOut(auth).finally(() => {
           window.location.href = "./user_login.html";

--- a/userSide/LOGIN_SIGNUP/signup.html
+++ b/userSide/LOGIN_SIGNUP/signup.html
@@ -128,7 +128,7 @@
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getAuth, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import { getAuth, createUserWithEmailAndPassword, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
     async function loadFirebase() {
       const response = await fetch('../../PHP/firebase_config.php', { credentials: 'same-origin' });
       if (!response.ok) {
@@ -136,6 +136,16 @@
       }
       const app = initializeApp(await response.json());
       const auth = getAuth(app);
+
+      window.auth = auth;
+      window.getAuth = getAuth;
+      onAuthStateChanged(auth, user => {
+        if (user) {
+          console.log('Logged in as:', user.email);
+        } else {
+          console.log('Not logged in');
+        }
+      });
 
       const video = document.getElementById('video');
       const captureBtn = document.getElementById('captureBtn');

--- a/userSide/LOGIN_SIGNUP/user_login.html
+++ b/userSide/LOGIN_SIGNUP/user_login.html
@@ -151,7 +151,7 @@
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
     async function loadFirebase() {
       const response = await fetch('../../PHP/firebase_config.php', { credentials: 'same-origin' });
       if (!response.ok) {
@@ -159,6 +159,16 @@
       }
       const app = initializeApp(await response.json());
       const auth = getAuth(app);
+
+      window.auth = auth;
+      window.getAuth = getAuth;
+      onAuthStateChanged(auth, user => {
+        if (user) {
+          console.log('Logged in as:', user.email);
+        } else {
+          console.log('Not logged in');
+        }
+      });
 
       window.login = (e) => {
         e.preventDefault();

--- a/userSide/PRODUCT/MENU.html
+++ b/userSide/PRODUCT/MENU.html
@@ -483,6 +483,7 @@
   </footer>
   </section>
 
+  <script type="module" src="../firebase-init.js"></script>
   <script>
     function toggleDropdown() {
       const dropdown = document.getElementById("profileDropdown");

--- a/userSide/PROFILE/EditProfile.html
+++ b/userSide/PROFILE/EditProfile.html
@@ -217,6 +217,7 @@
     </form>
   </div>
 
+  <script type="module" src="../firebase-init.js"></script>
   <script>
     function toggleDropdown() {
       const dropdown = document.getElementById("profileDropdown");

--- a/userSide/PROFILE/Settings.html
+++ b/userSide/PROFILE/Settings.html
@@ -241,6 +241,7 @@
     <button class="save-btn" onclick="alert('Settings saved!')">Save Settings</button>
   </div>
 
+  <script type="module" src="../firebase-init.js"></script>
   <script>
     function toggleDropdown() {
       const dropdown = document.getElementById("profileDropdown");

--- a/userSide/PURCHASES/MyPurchase.html
+++ b/userSide/PURCHASES/MyPurchase.html
@@ -388,5 +388,6 @@
 
     window.addEventListener('DOMContentLoaded', loadCartItems);
   </script>
+  <script type="module" src="../firebase-init.js"></script>
 </body>
 </html>

--- a/userSide/firebase-init.js
+++ b/userSide/firebase-init.js
@@ -1,0 +1,24 @@
+import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+
+async function loadFirebase() {
+  if (!getApps().length) {
+    const response = await fetch('../PHP/firebase_config.php', { credentials: 'same-origin' });
+    if (!response.ok) {
+      throw new Error('Unable to load Firebase configuration');
+    }
+    initializeApp(await response.json());
+  }
+  const auth = getAuth();
+  window.auth = auth;
+  window.getAuth = getAuth;
+  onAuthStateChanged(auth, user => {
+    if (user) {
+      console.log('Logged in as:', user.email);
+    } else {
+      console.log('Not logged in');
+    }
+  });
+}
+
+loadFirebase().catch(err => console.error('Firebase init failed:', err));


### PR DESCRIPTION
## Summary
- add shared Firebase init module with auth state logging
- load Firebase init on all user-facing pages
- expose auth state on login, signup, and logout screens for debugging

## Testing
- `php -l userSide/CART/cart_checkout_page.html`
- `php -l 'userSide/FAVORITE/my favorite.html'`
- `php -l 'userSide/HOME PAGING/MENU.html'`
- `php -l 'userSide/HOME PAGING/about.html'`
- `php -l userSide/INVOICE/orderDetails.html`
- `php -l userSide/LOGIN_SIGNUP/logout.html`
- `php -l userSide/LOGIN_SIGNUP/signup.html`
- `php -l userSide/LOGIN_SIGNUP/user_login.html`
- `php -l userSide/PRODUCT/MENU.html`
- `php -l userSide/PROFILE/EditProfile.html`
- `php -l userSide/PROFILE/Settings.html`
- `php -l userSide/PURCHASES/MyPurchase.html`


------
https://chatgpt.com/codex/tasks/task_e_68a7ced74c148324ac01c60804ad27b1