### PR TITLE
Use Firebase email for user-specific operations

### DIFF
--- a/PHP/cart_api.php
+++ b/PHP/cart_api.php
@@ -2,13 +2,25 @@
 require_once 'db_connect.php';
 require_once 'cart_functions.php';
 require_once 'cart_item_functions.php';
+require_once 'user_functions.php';
 
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 switch ($action) {
     case 'list':
-        $userId = (int)($_GET['user_id'] ?? 0);
+        $email = $_GET['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            $userId = (int)$user['User_ID'];
+        } else {
+            $userId = (int)($_GET['user_id'] ?? 0);
+        }
         $cart = getCartByUserId($pdo, $userId);
         if (!$cart) {
             $cartId = createCart($pdo, $userId);

--- a/PHP/favorite_api.php
+++ b/PHP/favorite_api.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'db_connect.php';
 require_once 'favorite_functions.php';
+require_once 'user_functions.php';
 
 header('Content-Type: application/json');
 
@@ -8,12 +9,34 @@ $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 switch ($action) {
     case 'list':
-        $userId = (int)($_GET['user_id'] ?? 0);
+        $email = $_GET['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            $userId = (int)$user['User_ID'];
+        } else {
+            $userId = (int)($_GET['user_id'] ?? 0);
+        }
         $favorites = getFavoritesByUserId($pdo, $userId);
         echo json_encode($favorites);
         break;
     case 'add':
-        $userId = (int)($_POST['user_id'] ?? 0);
+        $email = $_POST['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            $userId = (int)$user['User_ID'];
+        } else {
+            $userId = (int)($_POST['user_id'] ?? 0);
+        }
         $productId = (int)($_POST['product_id'] ?? 0);
         $id = addFavorite($pdo, $userId, $productId);
         echo json_encode(['favorite_id' => $id]);

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -2,18 +2,41 @@
 require_once 'db_connect.php';
 require_once 'order_functions.php';
 require_once 'order_item_functions.php';
+require_once 'user_functions.php';
 
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 switch ($action) {
     case 'list':
-        $userId = (int)($_GET['user_id'] ?? 0);
+        $email = $_GET['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            $userId = (int)$user['User_ID'];
+        } else {
+            $userId = (int)($_GET['user_id'] ?? 0);
+        }
         $orders = getOrdersByUserId($pdo, $userId);
         echo json_encode($orders);
         break;
     case 'create':
-        $userId = (int)($_POST['user_id'] ?? 0);
+        $email = $_POST['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            $userId = (int)$user['User_ID'];
+        } else {
+            $userId = (int)($_POST['user_id'] ?? 0);
+        }
         $items = json_decode($_POST['items'] ?? '[]', true);
         $orderId = addOrder($pdo, $userId, date('Y-m-d'), 'Pending');
         foreach ($items as $it) {

--- a/PHP/user_api.php
+++ b/PHP/user_api.php
@@ -7,12 +7,34 @@ $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 switch ($action) {
     case 'get_face':
-        $userId = (int)($_GET['user_id'] ?? 0);
-        $user = getUserById($pdo, $userId);
-        echo json_encode(['face_image_path' => $user['Face_Image_Path'] ?? null]);
+        $email = $_GET['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            echo json_encode(['face_image_path' => $user['Face_Image_Path'] ?? null]);
+        } else {
+            $userId = (int)($_GET['user_id'] ?? 0);
+            $user = getUserById($pdo, $userId);
+            echo json_encode(['face_image_path' => $user['Face_Image_Path'] ?? null]);
+        }
         break;
     case 'set_face':
-        $userId = (int)($_POST['user_id'] ?? 0);
+        $email = $_POST['email'] ?? '';
+        if ($email) {
+            $user = getUserByEmail($pdo, $email);
+            if (!$user) {
+                http_response_code(404);
+                echo json_encode(['error' => 'User not found']);
+                break;
+            }
+            $userId = (int)$user['User_ID'];
+        } else {
+            $userId = (int)($_POST['user_id'] ?? 0);
+        }
         $path = $_POST['face_image_path'] ?? '';
         $stmt = $pdo->prepare('UPDATE User SET Face_Image_Path = :path WHERE User_ID = :id');
         $stmt->execute([':path' => $path, ':id' => $userId]);

--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -354,8 +354,11 @@
     <button class="back-btn" onclick="goBack()">← Back to Cart</button>
   </div>
 
-  <script>
-      function toggleDropdown() {
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../firebase-init.js";
+
+    function toggleDropdown() {
       const dropdown = document.getElementById("profileDropdown");
       dropdown.style.display = dropdown.style.display === "block" ? "none" : "block";
     }
@@ -374,9 +377,19 @@
     const masterCheckbox = document.querySelector('.check-all input[type="checkbox"]');
     let cartId = null;
     let checkoutData = [];
+    let userEmail = null;
+
+    const auth = getAuth();
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        userEmail = user.email;
+        loadCart();
+      }
+    });
 
     async function loadCart() {
-      const res = await fetch('../../PHP/cart_api.php?action=list&user_id=1');
+      if (!userEmail) return;
+      const res = await fetch(`../../PHP/cart_api.php?action=list&email=${encodeURIComponent(userEmail)}`);
       const data = await res.json();
       cartId = data.cart_id;
       const cart = data.items;
@@ -543,7 +556,7 @@
       fetch('../../PHP/order_api.php?action=create', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: `user_id=1&items=${encodeURIComponent(JSON.stringify(checkoutData))}`
+        body: `email=${encodeURIComponent(userEmail)}&items=${encodeURIComponent(JSON.stringify(checkoutData))}`
       })
       .then(res => res.json())
       .then(data => {
@@ -552,9 +565,7 @@
         loadCart();
       });
     }
-
-    window.addEventListener("DOMContentLoaded", loadCart);
   </script>
-  <script type="module" src="../firebase-init.js"></script>
+  
 </body>
 </html>

--- a/userSide/FAVORITE/my favorite.html
+++ b/userSide/FAVORITE/my favorite.html
@@ -138,36 +138,45 @@
     <div class="no-favorites" id="noFavorites" style="display:none;">No favorite products found.</div>
   </section>
 
-  <script>
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../firebase-init.js";
+
     const grid = document.getElementById('favoritesGrid');
     const noFav = document.getElementById('noFavorites');
 
-    fetch('../../PHP/favorite_api.php?action=list&user_id=1')
-      .then(res => res.json())
-      .then(favorites => {
-        if (!favorites || favorites.length === 0) {
-          noFav.style.display = 'block';
-          return;
-        }
+    const auth = getAuth();
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        fetch(`../../PHP/favorite_api.php?action=list&email=${encodeURIComponent(user.email)}`)
+          .then(res => res.json())
+          .then(favorites => {
+            if (!favorites || favorites.length === 0) {
+              noFav.style.display = 'block';
+              return;
+            }
 
-        favorites.forEach(product => {
-          const div = document.createElement('div');
-          div.className = 'favorite-item';
-          div.innerHTML = `
-            <a href="../PRODUCT/product.php?id=${product.Product_ID}">
-              <img src="${product.Image_Path}" alt="${product.Name}">
-              <div class="product-name">${product.Name}</div>
-            </a>
-            <a href="../LOGIN_SIGNUP/user_login.html" class="order-now">Order Now</a>
-          `;
-          grid.appendChild(div);
-        });
-      })
-      .catch(() => {
+            favorites.forEach(product => {
+              const div = document.createElement('div');
+              div.className = 'favorite-item';
+              div.innerHTML = `
+                <a href="../PRODUCT/product.php?id=${product.Product_ID}">
+                  <img src="${product.Image_Path}" alt="${product.Name}">
+                  <div class="product-name">${product.Name}</div>
+                </a>
+                <a href="../LOGIN_SIGNUP/user_login.html" class="order-now">Order Now</a>
+              `;
+              grid.appendChild(div);
+            });
+          })
+          .catch(() => {
+            noFav.style.display = 'block';
+          });
+      } else {
         noFav.style.display = 'block';
-      });
+      }
+    });
   </script>
-  <script type="module" src="../firebase-init.js"></script>
 
 </body>
 </html>

--- a/userSide/PROFILE/EditProfile.html
+++ b/userSide/PROFILE/EditProfile.html
@@ -217,8 +217,10 @@
     </form>
   </div>
 
-  <script type="module" src="../firebase-init.js"></script>
-  <script>
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../firebase-init.js";
+
     function toggleDropdown() {
       const dropdown = document.getElementById("profileDropdown");
       dropdown.style.display = dropdown.style.display === "block" ? "none" : "block";
@@ -234,16 +236,18 @@
       }
     };
 
-  
-    window.onload = () => {
-      fetch('../../PHP/user_api.php?action=get_face&user_id=1')
-        .then(res => res.json())
-        .then(data => {
-          if (data.face_image_path) {
-            document.getElementById('profilePic').src = data.face_image_path;
-          }
-        });
-    };
+    const auth = getAuth();
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        fetch(`../../PHP/user_api.php?action=get_face&email=${encodeURIComponent(user.email)}`)
+          .then(res => res.json())
+          .then(data => {
+            if (data.face_image_path) {
+              document.getElementById('profilePic').src = data.face_image_path;
+            }
+          });
+      }
+    });
 
     document.getElementById("editProfileForm").addEventListener("submit", function(e) {
       e.preventDefault();

--- a/userSide/PROFILE/Settings.php
+++ b/userSide/PROFILE/Settings.php
@@ -1,10 +1,17 @@
 <?php
-session_start();
 require_once '../../PHP/db_connect.php';
 require_once '../../PHP/user_functions.php';
 
-$userId = $_SESSION['user_id'] ?? null;
+$email = $_GET['email'] ?? $_POST['email'] ?? '';
+$userId = null;
 $message = '';
+
+if ($email) {
+    $user = getUserByEmail($pdo, $email);
+    if ($user) {
+        $userId = $user['User_ID'];
+    }
+}
 
 // Default settings
 $userSettings = [
@@ -16,14 +23,11 @@ $userSettings = [
 ];
 
 if ($userId) {
-    $user = getUserById($pdo, $userId);
-    if ($user) {
-        $userSettings['language'] = $user['Language'] ?? 'English';
-        $userSettings['theme'] = $user['Theme'] ?? 'Light';
-        $userSettings['notify_order'] = $user['Notify_Order_Status'] ?? 0;
-        $userSettings['notify_promotions'] = $user['Notify_Promotions'] ?? 0;
-        $userSettings['notify_feedback'] = $user['Notify_Feedback'] ?? 0;
-    }
+    $userSettings['language'] = $user['Language'] ?? 'English';
+    $userSettings['theme'] = $user['Theme'] ?? 'Light';
+    $userSettings['notify_order'] = $user['Notify_Order_Status'] ?? 0;
+    $userSettings['notify_promotions'] = $user['Notify_Promotions'] ?? 0;
+    $userSettings['notify_feedback'] = $user['Notify_Feedback'] ?? 0;
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $userId) {
@@ -267,6 +271,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $userId) {
       <p class="message"><?php echo htmlspecialchars($message); ?></p>
     <?php endif; ?>
     <form method="POST" action="">
+      <input type="hidden" name="email" value="<?php echo htmlspecialchars($email); ?>">
     <div class="settings-section">
       <h3>Account Preferences</h3>
       <label for="language">Language</label>

--- a/userSide/PURCHASES/MyPurchase.html
+++ b/userSide/PURCHASES/MyPurchase.html
@@ -307,7 +307,10 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../firebase-init.js";
+
     let cancelIndex = null;
 
     function toggleDropdown() {
@@ -332,9 +335,19 @@
       document.querySelectorAll('.tab')[index].classList.add('active');
     }
 
+    let userEmail = null;
+    const auth = getAuth();
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        userEmail = user.email;
+        loadCartItems();
+      }
+    });
+
     function loadCartItems() {
+      if (!userEmail) return;
       const container = document.getElementById('cart-items-container');
-      fetch('../../PHP/order_api.php?action=list&user_id=1')
+      fetch(`../../PHP/order_api.php?action=list&email=${encodeURIComponent(userEmail)}`)
         .then(res => res.json())
         .then(orders => {
           if (!orders || orders.length === 0) {
@@ -388,6 +401,5 @@
 
     window.addEventListener('DOMContentLoaded', loadCartItems);
   </script>
-  <script type="module" src="../firebase-init.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Identify user by Firebase email in cart, favorites, orders, and profile APIs
- Update user-side pages to fetch using logged-in email instead of hardcoded IDs
- Load profile settings by email rather than PHP session

## Testing
- `php -l PHP/cart_api.php`
- `php -l PHP/favorite_api.php`
- `php -l PHP/order_api.php`
- `php -l PHP/user_api.php`
- `php -l userSide/PROFILE/Settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9690bffb4832480c1ea03eb7d8b0e