### PR TITLE
Record user transactions on purchase

### DIFF
--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -2,6 +2,7 @@
 require_once 'db_connect.php';
 require_once 'order_functions.php';
 require_once 'order_item_functions.php';
+require_once 'transaction_functions.php';
 require_once 'user_functions.php';
 
 header('Content-Type: application/json');
@@ -38,14 +39,18 @@ switch ($action) {
             $userId = (int)($_POST['user_id'] ?? 0);
         }
         $items = json_decode($_POST['items'] ?? '[]', true);
+        $mop   = $_POST['mop'] ?? '';
         $orderId = addOrder($pdo, $userId, date('Y-m-d'), 'Pending');
+        $total = 0;
         foreach ($items as $it) {
             $stmt = $pdo->prepare('SELECT Price FROM Product WHERE Product_ID = :id');
             $stmt->execute([':id' => $it['product_id']]);
             $price = $stmt->fetchColumn();
             $subtotal = $price * $it['quantity'];
+            $total += $subtotal;
             addOrderItem($pdo, $orderId, $it['product_id'], $it['quantity'], $subtotal);
         }
+        addTransaction($pdo, $orderId, $mop, 'Pending', date('Y-m-d'), $total, null);
         echo json_encode(['order_id' => $orderId]);
         break;
     case 'view':
@@ -54,7 +59,10 @@ switch ($action) {
         $stmt = $pdo->prepare('SELECT oi.Quantity, oi.Subtotal, p.Name FROM Order_Item oi JOIN Product p ON oi.Product_ID = p.Product_ID WHERE oi.Order_ID = :order_id');
         $stmt->execute([':order_id' => $orderId]);
         $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['order' => $order, 'items' => $items]);
+        $stmt = $pdo->prepare('SELECT Payment_Method, Payment_Status, Amount_Paid, Reference_Number FROM Transaction WHERE Order_ID = :order_id');
+        $stmt->execute([':order_id' => $orderId]);
+        $transaction = $stmt->fetch(PDO::FETCH_ASSOC);
+        echo json_encode(['order' => $order, 'items' => $items, 'transaction' => $transaction]);
         break;
     default:
         http_response_code(400);

--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -363,7 +363,7 @@
       .then(res => res.json())
       .then(data => {
         document.getElementById("confirmationMsg").innerHTML =
-          `🎉 Thank you, <b>${name}</b>! Your order has been placed. <br><br><a href="orderDetails.html?order_id=${data.order_id}" style="color:blue;text-decoration:underline;">👉 View Order Details</a>`;
+          `🎉 Thank you, <b>${name}</b>! Your order has been placed. <br><br><a href="../INVOICE/orderDetails.html?order_id=${data.order_id}" style="color:blue;text-decoration:underline;">👉 View Order Details</a>`;
         loadCart();
       });
     }

--- a/userSide/INVOICE/orderDetails.html
+++ b/userSide/INVOICE/orderDetails.html
@@ -47,9 +47,10 @@
           return;
         }
         const order = data.order;
+        const transaction = data.transaction || {};
         document.getElementById('name').textContent = order.User_ID;
         document.getElementById('address').textContent = order.Address || '';
-        document.getElementById('mop').textContent = order.Status;
+        document.getElementById('mop').textContent = transaction.Payment_Method || '';
         document.getElementById('date').textContent = order.Order_Date;
 
         const tbody = document.getElementById('items-list');


### PR DESCRIPTION
## Summary
- log a transaction whenever an order is placed, capturing payment method and total
- expose transaction details in order view and invoice page for display

## Testing
- `php -l PHP/order_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68aac229adf483248c5c403f0b5f019c