### PR TITLE
Enforce stock limits and update inventory on order creation

### DIFF
--- a/PHP/cart_api.php
+++ b/PHP/cart_api.php
@@ -27,7 +27,7 @@ switch ($action) {
             $items = [];
         } else {
             $cartId = $cart['Cart_ID'];
-            $stmt = $pdo->prepare("SELECT ci.Cart_Item_ID, ci.Product_ID, ci.Quantity, p.Name, p.Price, p.Image_Path FROM cart_item ci JOIN product p ON ci.Product_ID = p.Product_ID WHERE ci.Cart_ID = :cart_id");
+            $stmt = $pdo->prepare("SELECT ci.Cart_Item_ID, ci.Product_ID, ci.Quantity, p.Name, p.Price, p.Stock_Quantity, p.Image_Path FROM cart_item ci JOIN product p ON ci.Product_ID = p.Product_ID WHERE ci.Cart_ID = :cart_id");
             $stmt->execute([':cart_id' => $cartId]);
             $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
         }

--- a/PHP/cart_api.php
+++ b/PHP/cart_api.php
@@ -59,8 +59,15 @@ switch ($action) {
             $cartId = $cart ? $cart['Cart_ID'] : createCart($pdo, $userId);
         }
 
-        $id = addCartItem($pdo, $cartId, $productId, $qty);
-        echo json_encode(['cart_item_id' => $id, 'cart_id' => $cartId]);
+        $existing = getCartItemByCartAndProduct($pdo, $cartId, $productId);
+        if ($existing) {
+            $newQty = $existing['Quantity'] + $qty;
+            $updated = updateCartItemQuantity($pdo, $existing['Cart_Item_ID'], $newQty);
+            echo json_encode(['cart_item_id' => $existing['Cart_Item_ID'], 'cart_id' => $cartId, 'updated' => $updated]);
+        } else {
+            $id = addCartItem($pdo, $cartId, $productId, $qty);
+            echo json_encode(['cart_item_id' => $id, 'cart_id' => $cartId]);
+        }
         break;
     case 'update':
         $cartItemId = (int)($_POST['cart_item_id'] ?? 0);

--- a/PHP/cart_api.php
+++ b/PHP/cart_api.php
@@ -72,8 +72,12 @@ switch ($action) {
     case 'update':
         $cartItemId = (int)($_POST['cart_item_id'] ?? 0);
         $qty = (int)($_POST['quantity'] ?? 1);
-        $updated = updateCartItemQuantity($pdo, $cartItemId, $qty);
-        echo json_encode(['updated' => $updated]);
+        $result = updateCartItemQuantity($pdo, $cartItemId, $qty);
+        if ($qty <= 0) {
+            echo json_encode(['deleted' => $result]);
+        } else {
+            echo json_encode(['updated' => $result]);
+        }
         break;
     case 'remove':
         $cartItemId = (int)($_POST['cart_item_id'] ?? 0);

--- a/PHP/cart_item_functions.php
+++ b/PHP/cart_item_functions.php
@@ -42,6 +42,9 @@ function getCartItemById($pdo, $cartItemId) {
 
 // 5) Update quantity of a cart item
 function updateCartItemQuantity($pdo, $cartItemId, $quantity) {
+    if ($quantity <= 0) {
+        return deleteCartItemById($pdo, $cartItemId);
+    }
     $stmt = $pdo->prepare("
         UPDATE cart_item
         SET Quantity = :quantity

--- a/PHP/cart_item_functions.php
+++ b/PHP/cart_item_functions.php
@@ -80,4 +80,16 @@ function deleteCartItemsByProductId($pdo, $productId) {
     $stmt->execute([':product_id' => $productId]);
     return $stmt->rowCount();
 }
+
+// 9) Get a cart item by cart and product
+function getCartItemByCartAndProduct($pdo, $cartId, $productId) {
+    $stmt = $pdo->prepare("
+        SELECT * FROM cart_item WHERE Cart_ID = :cart_id AND Product_ID = :product_id
+    ");
+    $stmt->execute([
+        ':cart_id' => $cartId,
+        ':product_id' => $productId
+    ]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
 ?>

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -6,6 +6,8 @@ require_once 'transaction_functions.php';
 require_once 'user_functions.php';
 require_once 'inventory_functions.php';
 require_once 'product_functions.php';
+require_once 'cart_functions.php';
+require_once 'cart_item_functions.php';
 
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
@@ -65,6 +67,10 @@ switch ($action) {
             adjustProductStock($pdo, $it['product_id'], -$it['quantity']);
         }
         addTransaction($pdo, $orderId, $mop, 'Pending', date('Y-m-d'), $total, null);
+        $cart = getCartByUserId($pdo, $userId);
+        if ($cart) {
+            deleteCartItemsByCartId($pdo, $cart['Cart_ID']);
+        }
         echo json_encode(['order_id' => $orderId]);
         break;
     case 'view':

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -4,6 +4,7 @@ require_once 'order_functions.php';
 require_once 'order_item_functions.php';
 require_once 'transaction_functions.php';
 require_once 'user_functions.php';
+require_once 'inventory_functions.php';
 
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
@@ -40,6 +41,16 @@ switch ($action) {
         }
         $items = json_decode($_POST['items'] ?? '[]', true);
         $mop   = $_POST['mop'] ?? '';
+
+        foreach ($items as $it) {
+            $inventory = getInventoryByProductId($pdo, $it['product_id']);
+            if (!$inventory || $inventory['Stock_Quantity'] < $it['quantity']) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Insufficient stock for product ID ' . $it['product_id']]);
+                exit;
+            }
+        }
+
         $orderId = addOrder($pdo, $userId, date('Y-m-d'), 'Pending');
         $total = 0;
         foreach ($items as $it) {
@@ -49,6 +60,7 @@ switch ($action) {
             $subtotal = $price * $it['quantity'];
             $total += $subtotal;
             addOrderItem($pdo, $orderId, $it['product_id'], $it['quantity'], $subtotal);
+            adjustInventoryStock($pdo, $it['product_id'], -$it['quantity']);
         }
         addTransaction($pdo, $orderId, $mop, 'Pending', date('Y-m-d'), $total, null);
         echo json_encode(['order_id' => $orderId]);

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -5,6 +5,7 @@ require_once 'order_item_functions.php';
 require_once 'transaction_functions.php';
 require_once 'user_functions.php';
 require_once 'inventory_functions.php';
+require_once 'product_functions.php';
 
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
@@ -61,6 +62,7 @@ switch ($action) {
             $total += $subtotal;
             addOrderItem($pdo, $orderId, $it['product_id'], $it['quantity'], $subtotal);
             adjustInventoryStock($pdo, $it['product_id'], -$it['quantity']);
+            adjustProductStock($pdo, $it['product_id'], -$it['quantity']);
         }
         addTransaction($pdo, $orderId, $mop, 'Pending', date('Y-m-d'), $total, null);
         echo json_encode(['order_id' => $orderId]);

--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -195,6 +195,7 @@
         div.setAttribute('data-id', item.Cart_Item_ID);
         div.setAttribute('data-product', item.Product_ID);
         div.setAttribute('data-price', item.Price);
+        div.setAttribute('data-stock', item.Stock_Quantity);
         div.innerHTML = `
           <div class="cart-item-left">
             <input type="checkbox" class="item-check" checked>
@@ -323,7 +324,14 @@
         if (checkbox.checked) {
           hasItem = true;
           const name = item.querySelector('.item-details b').textContent;
-          const qty = item.querySelector('.qty-display').textContent;
+          let qty = parseInt(item.querySelector('.qty-display').textContent, 10);
+          const stock = parseInt(item.getAttribute('data-stock'), 10);
+          if (qty > stock) {
+            alert(`${name} quantity reduced to available stock of ${stock}.`);
+            qty = stock;
+            item.querySelector('.qty-display').textContent = stock;
+            saveQty(item.querySelector('.increase-btn'), stock);
+          }
           const price = parseFloat(item.getAttribute('data-price'));
           const total = price * qty;
 
@@ -331,9 +339,11 @@
           div.classList.add("summary-item");
           div.innerHTML = `<span>${name} x${qty}</span><span>₱${total.toFixed(2)}</span>`;
           checkoutItems.appendChild(div);
-          checkoutData.push({product_id: item.getAttribute('data-product'), quantity: parseInt(qty)});
+          checkoutData.push({product_id: item.getAttribute('data-product'), quantity: qty});
         }
       });
+
+      updateTotal();
 
       if (!hasItem) {
         alert("Please select at least one item to check out.");

--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -276,11 +276,17 @@
     }
 
     function saveQty(button, newQty) {
-      const id = button.closest('.cart-item').getAttribute('data-id');
+      const item = button.closest('.cart-item');
+      const id = item.getAttribute('data-id');
       fetch('../../PHP/cart_api.php?action=update', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: `cart_item_id=${id}&quantity=${newQty}`
+      }).then(() => {
+        if (newQty <= 0) {
+          item.remove();
+        }
+        updateTotal();
       });
     }
 
@@ -322,16 +328,24 @@
       document.querySelectorAll('.cart-item').forEach(item => {
         const checkbox = item.querySelector('.item-check');
         if (checkbox.checked) {
-          hasItem = true;
           const name = item.querySelector('.item-details b').textContent;
           let qty = parseInt(item.querySelector('.qty-display').textContent, 10);
           const stock = parseInt(item.getAttribute('data-stock'), 10);
           if (qty > stock) {
+            if (stock <= 0) {
+              alert(`${name} is out of stock and has been removed from your cart.`);
+              saveQty(item.querySelector('.increase-btn'), 0);
+              return;
+            }
             alert(`${name} quantity reduced to available stock of ${stock}.`);
             qty = stock;
             item.querySelector('.qty-display').textContent = stock;
             saveQty(item.querySelector('.increase-btn'), stock);
           }
+          if (qty <= 0) {
+            return;
+          }
+          hasItem = true;
           const price = parseFloat(item.getAttribute('data-price'));
           const total = price * qty;
 

--- a/userSide/CART/cart_checkout_page.html
+++ b/userSide/CART/cart_checkout_page.html
@@ -359,12 +359,36 @@
       document.getElementById("cart-section").style.display = "block";
     }
 
-    function placeOrder(e) {
+    async function placeOrder(e) {
       e.preventDefault();
       const name = document.getElementById("name").value;
       const address = document.getElementById("address").value;
       const orderType = document.getElementById("order-type").value;
       const mop = document.getElementById("mop").value;
+
+      const res = await fetch(`../../PHP/cart_api.php?action=list&email=${encodeURIComponent(userEmail)}`);
+      const latest = await res.json();
+      const shortages = [];
+      latest.items.forEach(it => {
+        const sel = checkoutData.find(c => c.product_id == it.Product_ID);
+        if (sel && sel.quantity > parseInt(it.Stock_Quantity, 10)) {
+          shortages.push({ id: it.Cart_Item_ID, name: it.Name, stock: parseInt(it.Stock_Quantity, 10) });
+        }
+      });
+
+      if (shortages.length) {
+        await Promise.all(shortages.map(s => fetch('../../PHP/cart_api.php?action=update', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+          body: `cart_item_id=${s.id}&quantity=${s.stock}`
+        })));
+        alert(shortages.map(s => `${s.name} quantity reduced to available stock of ${s.stock}.`).join('\n'));
+        loadCart();
+        document.getElementById("checkout-section").style.display = "none";
+        document.getElementById("cart-section").style.display = "block";
+        return;
+      }
+
       fetch('../../PHP/order_api.php?action=create', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},

--- a/userSide/PRODUCT/js/cart.js
+++ b/userSide/PRODUCT/js/cart.js
@@ -11,7 +11,7 @@ async function addToCart() {
     return false;
   }
   try {
-    // Ensure we have user info and a cart ID
+    // Ensure we have user info
     let email = null;
     try {
       const auth = window.getAuth ? window.getAuth() : null;
@@ -20,32 +20,45 @@ async function addToCart() {
       console.error("Auth unavailable", e);
     }
 
-    let cartId = localStorage.getItem("cart_id");
-    if (!cartId) {
-      const listUrl = email
-        ? `/PHP/cart_api.php?action=list&email=${encodeURIComponent(email)}`
-        : `/PHP/cart_api.php?action=list`;
-      const listResp = await fetch(listUrl);
-      const listText = await listResp.text();
-      let listData;
-      try {
-        listData = JSON.parse(listText);
-      } catch (e) {
-        console.error("Invalid cart list response", listText);
-        alert("Error retrieving cart.");
-        return false;
-      }
-      cartId = listData.cart_id;
-      localStorage.setItem("cart_id", cartId);
+    const listUrl = email
+      ? `/PHP/cart_api.php?action=list&email=${encodeURIComponent(email)}`
+      : `/PHP/cart_api.php?action=list`;
+    const listResp = await fetch(listUrl);
+    const listText = await listResp.text();
+    let listData;
+    try {
+      listData = JSON.parse(listText);
+    } catch (e) {
+      console.error("Invalid cart list response", listText);
+      alert("Error retrieving cart.");
+      return false;
     }
+    const cartId = listData.cart_id;
+    localStorage.setItem("cart_id", cartId);
+    const existing = listData.items.find(
+      (item) => String(item.Product_ID) === String(productId)
+    );
 
     const params = new URLSearchParams();
-    params.set("cart_id", cartId);
-    params.set("product_id", productId);
-    params.set("quantity", qty);
+    let action = "add";
+    let newQty = qty;
+    if (existing) {
+      newQty = parseInt(existing.Quantity, 10) + qty;
+      if (typeof window.maxStock !== 'undefined' && newQty > window.maxStock) {
+        alert(`Only ${window.maxStock} left in stock.`);
+        return false;
+      }
+      action = "update";
+      params.set("cart_item_id", existing.Cart_Item_ID);
+      params.set("quantity", newQty);
+    } else {
+      params.set("cart_id", cartId);
+      params.set("product_id", productId);
+      params.set("quantity", qty);
+    }
     if (email) params.set("email", email);
 
-    const response = await fetch("/PHP/cart_api.php?action=add", {
+    const response = await fetch(`/PHP/cart_api.php?action=${action}`, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: params.toString()
@@ -55,12 +68,12 @@ async function addToCart() {
     try {
       result = JSON.parse(respText);
     } catch (e) {
-      console.error("Invalid add-to-cart response", respText);
+      console.error("Invalid cart response", respText);
       alert("Error adding item to cart.");
       return false;
     }
-    if (result.cart_item_id) {
-      alert("Item added to cart!");
+    if ((action === "add" && result.cart_item_id) || (action === "update" && result.updated)) {
+      alert(action === "add" ? "Item added to cart!" : "Cart quantity updated!");
       return true;
     } else {
       alert("Failed to add item to cart.");

--- a/userSide/PRODUCT/js/cart.js
+++ b/userSide/PRODUCT/js/cart.js
@@ -1,6 +1,10 @@
 async function addToCart() {
   const qtyEl = document.getElementById("qty");
   const qty = qtyEl ? parseInt(qtyEl.value, 10) || 1 : 1;
+  if (typeof window.maxStock !== 'undefined' && qty > window.maxStock) {
+    alert(`Only ${window.maxStock} left in stock.`);
+    return false;
+  }
   const productId = new URLSearchParams(window.location.search).get("id");
   if (!productId) {
     alert("Missing product id.");

--- a/userSide/PRODUCT/product.php
+++ b/userSide/PRODUCT/product.php
@@ -326,7 +326,7 @@ $price = isset($product['Price']) ? number_format((float)$product['Price'], 2) :
           <div class="price">Php <?= htmlspecialchars($price) ?></div>
           <span class="favorite-icon" onclick="toggleFavorite(this)">❤️</span>
         </div>
-        <div class="stock">Stock: <?= htmlspecialchars($product['Stock_Quantity'] ?? '') ?></div>
+        <div class="stock" id="stockDisplay">Stock: <?= htmlspecialchars($product['Stock_Quantity'] ?? '') ?></div>
         <h2><?= htmlspecialchars($product['Name']) ?></h2>
         <p><?= htmlspecialchars($product['Description'] ?? '') ?></p>
 
@@ -349,11 +349,62 @@ $price = isset($product['Price']) ? number_format((float)$product['Price'], 2) :
   <script type="module" src="../firebase-init.js"></script>
   <script src="js/cart.js"></script>
   <script>
-    const maxStock = <?= (int)($product['Stock_Quantity'] ?? 0); ?>;
-    if (maxStock === 0) {
-      document.querySelector('.add-to-cart').disabled = true;
-      document.querySelector('.buy-now').disabled = true;
+    let maxStock = <?= (int)($product['Stock_Quantity'] ?? 0); ?>;
+    window.maxStock = maxStock;
+
+    async function updateMaxStockFromCart() {
+      const productId = <?= (int)$id ?>;
+      try {
+        let email = null;
+        try {
+          const auth = window.getAuth ? window.getAuth() : null;
+          email = auth && auth.currentUser ? auth.currentUser.email : null;
+        } catch (e) {
+          console.error("Auth unavailable", e);
+        }
+
+        const listUrl = email
+          ? `/PHP/cart_api.php?action=list&email=${encodeURIComponent(email)}`
+          : `/PHP/cart_api.php?action=list`;
+        const resp = await fetch(listUrl);
+        const text = await resp.text();
+        let data;
+        try {
+          data = JSON.parse(text);
+        } catch (e) {
+          console.error("Invalid cart list response", text);
+          return;
+        }
+        if (data.items) {
+          const existing = data.items.find(
+            (item) => String(item.Product_ID) === String(productId)
+          );
+          if (existing) {
+            const existingQty = parseInt(existing.Quantity, 10) || 0;
+            maxStock = Math.max(0, maxStock - existingQty);
+            window.maxStock = maxStock;
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch cart", err);
+      }
+
+      const stockEl = document.getElementById('stockDisplay');
+      if (stockEl) stockEl.textContent = `Stock: ${maxStock}`;
+
+      const qtyEl = document.getElementById('qty');
+      if (qtyEl) {
+        if (maxStock === 0) qtyEl.value = 0;
+        else if (parseInt(qtyEl.value, 10) > maxStock) qtyEl.value = maxStock;
+      }
+
+      if (maxStock === 0) {
+        document.querySelector('.add-to-cart').disabled = true;
+        document.querySelector('.buy-now').disabled = true;
+      }
     }
+
+    updateMaxStockFromCart();
 
     function changeQty(delta) {
       const qty = document.getElementById('qty');

--- a/userSide/PRODUCT/product.php
+++ b/userSide/PRODUCT/product.php
@@ -349,12 +349,22 @@ $price = isset($product['Price']) ? number_format((float)$product['Price'], 2) :
   <script type="module" src="../firebase-init.js"></script>
   <script src="js/cart.js"></script>
   <script>
+    const maxStock = <?= (int)($product['Stock_Quantity'] ?? 0); ?>;
+    if (maxStock === 0) {
+      document.querySelector('.add-to-cart').disabled = true;
+      document.querySelector('.buy-now').disabled = true;
+    }
+
     function changeQty(delta) {
       const qty = document.getElementById('qty');
       let current = parseInt(qty.value);
       current = isNaN(current) ? 1 : current;
       current += delta;
       if (current < 1) current = 1;
+      if (current > maxStock) {
+        current = maxStock;
+        alert(`Only ${maxStock} left in stock.`);
+      }
       qty.value = current;
     }
 


### PR DESCRIPTION
## Summary
- Require inventory functions in order API
- Validate available stock before creating orders and deny excess purchases
- Deduct purchased quantities from inventory when an order is placed

## Testing
- `php -l PHP/order_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68aacf0c88388324b9a4d93f2e12f6c6