### PR TITLE
Add low stock email alert

### DIFF
--- a/PHP/email_functions.php
+++ b/PHP/email_functions.php
@@ -1,0 +1,54 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+
+if (class_exists('Dotenv\\Dotenv')) {
+    $dotenv = \Dotenv\Dotenv::createImmutable(__DIR__ . '/../');
+    $dotenv->safeLoad();
+}
+
+/**
+ * Send a low-stock notification email using SMTP credentials.
+ *
+ * @param string $productName
+ * @param int    $stockQty
+ * @return void
+ */
+function sendLowStockEmail(string $productName, int $stockQty): void
+{
+    $host = $_ENV['BREVO_SMTP_HOST'] ?? '';
+    $port = (int)($_ENV['BREVO_SMTP_PORT'] ?? 587);
+    $username = $_ENV['BREVO_SMTP_USERNAME'] ?? '';
+    $password = $_ENV['BREVO_SMTP_PASSWORD'] ?? '';
+    $from = $_ENV['BREVO_FROM_EMAIL'] ?? '';
+    $fromName = $_ENV['BREVO_FROM_NAME'] ?? 'Stock Bot';
+
+    if (!$host || !$from) {
+        error_log('SMTP configuration incomplete.');
+        return;
+    }
+
+    $mail = new PHPMailer(true);
+
+    try {
+        $mail->isSMTP();
+        $mail->Host = $host;
+        $mail->Port = $port;
+        $mail->SMTPAuth = !empty($username);
+        if ($mail->SMTPAuth) {
+            $mail->Username = $username;
+            $mail->Password = $password;
+        }
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+        $mail->setFrom($from, $fromName);
+        $mail->addAddress($from);
+        $mail->Subject = 'Low Stock Alert: ' . $productName;
+        $mail->Body = "Stock for {$productName} is low. Current level: {$stockQty}.";
+        $mail->send();
+    } catch (Exception $e) {
+        error_log('Mailer Error: ' . $mail->ErrorInfo);
+    }
+}
+?>

--- a/PHP/email_functions.php
+++ b/PHP/email_functions.php
@@ -10,13 +10,13 @@ if (class_exists('Dotenv\\Dotenv')) {
 }
 
 /**
- * Send a low-stock notification email using SMTP credentials.
+ * Send an email to the admin using Brevo SMTP settings.
  *
- * @param string $productName
- * @param int    $stockQty
+ * @param string $subject
+ * @param string $body
  * @return void
  */
-function sendLowStockEmail(string $productName, int $stockQty): void
+function sendAdminEmail(string $subject, string $body): void
 {
     $host = $_ENV['BREVO_SMTP_HOST'] ?? '';
     $port = (int)($_ENV['BREVO_SMTP_PORT'] ?? 587);
@@ -44,11 +44,40 @@ function sendLowStockEmail(string $productName, int $stockQty): void
         $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
         $mail->setFrom($from, $fromName);
         $mail->addAddress($from);
-        $mail->Subject = 'Low Stock Alert: ' . $productName;
-        $mail->Body = "Stock for {$productName} is low. Current level: {$stockQty}.";
+        $mail->Subject = $subject;
+        $mail->Body = $body;
         $mail->send();
     } catch (Exception $e) {
         error_log('Mailer Error: ' . $mail->ErrorInfo);
     }
+}
+
+/**
+ * Send a low-stock notification email using SMTP credentials.
+ *
+ * @param string $productName
+ * @param int    $stockQty
+ * @return void
+ */
+function sendLowStockEmail(string $productName, int $stockQty): void
+{
+    $subject = 'Low Stock Alert: ' . $productName;
+    $body = "Stock for {$productName} is low. Current level: {$stockQty}.";
+    sendAdminEmail($subject, $body);
+}
+
+/**
+ * Notify the admin whenever a new order is placed.
+ *
+ * @param int   $orderId
+ * @param int   $userId
+ * @param float $total
+ * @return void
+ */
+function sendOrderNotificationEmail(int $orderId, int $userId, float $total): void
+{
+    $subject = 'New Order: #' . $orderId;
+    $body = "Order #{$orderId} has been placed by user ID {$userId}. Total amount: {$total}.";
+    sendAdminEmail($subject, $body);
 }
 ?>

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -8,6 +8,7 @@ require_once 'inventory_functions.php';
 require_once 'product_functions.php';
 require_once 'cart_functions.php';
 require_once 'cart_item_functions.php';
+require_once 'email_functions.php';
 
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
@@ -65,6 +66,12 @@ switch ($action) {
             addOrderItem($pdo, $orderId, $it['product_id'], $it['quantity'], $subtotal);
             adjustInventoryStock($pdo, $it['product_id'], -$it['quantity']);
             adjustProductStock($pdo, $it['product_id'], -$it['quantity']);
+
+            $inventory = getInventoryByProductId($pdo, $it['product_id']);
+            if ($inventory && $inventory['Stock_Quantity'] < 20) {
+                $product = getProductById($pdo, $it['product_id']);
+                sendLowStockEmail($product['Name'], (int)$inventory['Stock_Quantity']);
+            }
         }
         addTransaction($pdo, $orderId, $mop, 'Pending', date('Y-m-d'), $total, null);
         $cart = getCartByUserId($pdo, $userId);

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -78,6 +78,7 @@ switch ($action) {
         if ($cart) {
             deleteCartItemsByCartId($pdo, $cart['Cart_ID']);
         }
+        sendOrderNotificationEmail($orderId, $userId, $total);
         echo json_encode(['order_id' => $orderId]);
         break;
     case 'view':

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "vlucas/phpdotenv": "^5.6"
+        "vlucas/phpdotenv": "^5.6",
+        "phpmailer/phpmailer": "^6.9"
     }
 }


### PR DESCRIPTION
## Summary
- replace custom socket SMTP code with PHPMailer for Brevo-based low stock notifications
- declare PHPMailer as a Composer dependency

## Testing
- `php -l PHP/email_functions.php`
- `php -l PHP/order_api.php`
- `composer require phpmailer/phpmailer` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68abc333b94083249def12682aaba476