### PR TITLE
Fix undefined product name in order details

### DIFF
--- a/PHP/order_item_functions.php
+++ b/PHP/order_item_functions.php
@@ -17,10 +17,13 @@ function addOrderItem($pdo, $orderId, $productId, $quantity, $subtotal) {
 // 2) Get all order items for an order
 function getOrderItemsByOrderId($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Order_Item WHERE Order_ID = :order_id
+        SELECT oi.*, p.Name
+        FROM Order_Item oi
+        JOIN product p ON oi.Product_ID = p.Product_ID
+        WHERE oi.Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
-    return $stmt->fetchAll();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
 // 3) Get all order items for a product

--- a/adminSide/ORDERS/OrderDetails.php
+++ b/adminSide/ORDERS/OrderDetails.php
@@ -41,6 +41,7 @@ include '../header.php';
     <?php include $prefix . 'topbar.php'; ?>
 
     <div class="p-6">
+      <a href="ManageOrders.php" class="text-blue-500 hover:underline inline-block mb-4">&larr; Back to Orders</a>
       <?php if (!empty($message)): ?>
         <div class="mb-4 text-green-600"><?= $message; ?></div>
       <?php endif; ?>

--- a/adminSide/ORDERS/OrderDetails.php
+++ b/adminSide/ORDERS/OrderDetails.php
@@ -71,7 +71,7 @@ include '../header.php';
           <tbody>
             <?php foreach ($items as $item): ?>
               <tr class="border-b">
-                <td><?= htmlspecialchars($item['Name']); ?></td>
+                <td><?= htmlspecialchars($item['Name'] ?? 'Unknown Product'); ?></td>
                 <td><?= (int)$item['Quantity']; ?></td>
                 <td>₱ <?= number_format($item['Subtotal'], 2); ?></td>
               </tr>


### PR DESCRIPTION
## Summary
- Join products when fetching order items so each item includes its product name
- Show a fallback label if an order item lacks a product name

## Testing
- `php -l PHP/order_item_functions.php`
- `php -l adminSide/ORDERS/OrderDetails.php`


------
https://chatgpt.com/codex/tasks/task_e_68abe1603a848324938aa637438b4fd8