### PR TITLE
Add password reset page and link from login

### DIFF
--- a/userSide/LOGIN_SIGNUP/forgot_password.html
+++ b/userSide/LOGIN_SIGNUP/forgot_password.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Cindy's Login</title>
+  <meta charset="UTF-8" />
+  <title>Forgot Password</title>
   <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="login">
@@ -11,21 +11,21 @@
   <header>
     <nav>
       <a href="../HOME PAGING/HOME.HTML"><img src="../Images/home (2).png" alt="Home"> Home</a>
-      <a href="../LOGIN_SIGNUP/user_login.html" class="active"><img src="../Images/login (2).png" alt="Login"> Login</a>
+      <a href="../LOGIN_SIGNUP/user_login.html"><img src="../Images/login (2).png" alt="Login"> Login</a>
       <a href="../HOME PAGING/about.html" class="about"><img src="../Images/about.png" alt="About"> About</a>
       <a href="../LOGIN_SIGNUP/signup.html" class="signup"><img src="../Images/signup.png" alt="Signup"> Signup</a>
     </nav>
   </header>
 
-  <!-- Login Box -->
+  <!-- Forgot Password Box -->
   <div class="login-box">
-    <h2>LOGIN</h2>
-    <form onsubmit="login(event)">
+    <h2>RESET PASSWORD</h2>
+    <form onsubmit="resetPassword(event)">
       <input type="email" id="email" placeholder="Email" required>
-      <input type="password" id="password" placeholder="Password" required>
-      <button type="submit">LOGIN</button>
+      <button type="submit">SEND RESET EMAIL</button>
+      <div id="resetMessage" class="links" style="flex-direction: column; gap: 10px; text-align: center;"></div>
       <div class="links">
-        <a href="../LOGIN_SIGNUP/forgot_password.html">forgot password?</a>
+        <a href="../LOGIN_SIGNUP/user_login.html">back to login</a>
         <a href="../LOGIN_SIGNUP/signup.html">sign up</a>
       </div>
     </form>
@@ -33,7 +33,7 @@
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import { getAuth, sendPasswordResetEmail } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
     async function loadFirebase() {
       const configUrl = new URL('../../PHP/firebase_config.php', import.meta.url);
       const response = await fetch(configUrl, { credentials: 'same-origin' });
@@ -43,28 +43,21 @@
       const app = initializeApp(await response.json());
       const auth = getAuth(app);
 
-      window.auth = auth;
-      window.getAuth = getAuth;
-      onAuthStateChanged(auth, user => {
-        if (user) {
-          console.log('Logged in as:', user.email);
-        } else {
-          console.log('Not logged in');
-        }
-      });
-
-      window.login = (e) => {
+      window.resetPassword = async (e) => {
         e.preventDefault();
-
         const email = document.getElementById('email').value;
-        const password = document.getElementById('password').value;
-
-        signInWithEmailAndPassword(auth, email, password)
-          .then(() => window.location.href = '../PRODUCT/MENU.php')
-          .catch(err => alert(err.message));
+        const msg = document.getElementById('resetMessage');
+        msg.textContent = '';
+        try {
+          await sendPasswordResetEmail(auth, email);
+          msg.textContent = 'Password reset email sent!';
+          msg.style.color = 'green';
+        } catch (err) {
+          msg.textContent = err.message;
+          msg.style.color = 'red';
+        }
       };
     }
-
     loadFirebase().catch(err => console.error('Firebase init failed:', err));
   </script>
 


### PR DESCRIPTION
## Summary
- Add `forgot_password.html` with Firebase reset support and user feedback
- Link login page's "forgot password" anchor to the new reset page

## Testing
- `php -l PHP/firebase_config.php`


------
https://chatgpt.com/codex/tasks/task_e_68abf12702108324b181db5754f51f2a