### PR TITLE
style: restore original product card width

### DIFF
--- a/userSide/PRODUCT/bread.php
+++ b/userSide/PRODUCT/bread.php
@@ -57,7 +57,7 @@ if ($pdo) {
 
     .products-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
       gap: 25px;
       padding: 20px 40px;
     }
@@ -78,7 +78,7 @@ if ($pdo) {
     }
 
     .product-card img {
-      max-width: 160px;
+      max-width: 130px;
       height: auto;
       margin-bottom: 10px;
     }

--- a/userSide/PRODUCT/cakes.php
+++ b/userSide/PRODUCT/cakes.php
@@ -57,7 +57,7 @@ if ($pdo) {
 
     .products-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
       gap: 25px;
       padding: 20px 40px;
     }
@@ -78,7 +78,7 @@ if ($pdo) {
     }
 
     .product-card img {
-      max-width: 160px;
+      max-width: 130px;
       height: auto;
       margin-bottom: 10px;
     }

--- a/userSide/PRODUCT/pastry.php
+++ b/userSide/PRODUCT/pastry.php
@@ -58,7 +58,7 @@ if ($pdo) {
 
     .products-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
       gap: 25px;
       padding: 20px 40px;
     }
@@ -79,7 +79,7 @@ if ($pdo) {
     }
 
     .product-card img {
-      max-width: 160px;
+      max-width: 130px;
       height: auto;
       margin-bottom: 10px;
     }


### PR DESCRIPTION
## Summary
- narrow product cards on bread, cakes and pastry pages
- reduce product image width to match restored card size

## Testing
- `php -l userSide/PRODUCT/bread.php`
- `php -l userSide/PRODUCT/cakes.php`
- `php -l userSide/PRODUCT/pastry.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac2a0e9e9483249a1883651c48819f