### PR TITLE
fix: restore product card width

### DIFF
--- a/userSide/PRODUCT/bread.php
+++ b/userSide/PRODUCT/bread.php
@@ -60,6 +60,7 @@ if ($pdo) {
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 25px;
       padding: 20px 40px;
+      justify-content: center;
     }
 
     .product-card {
@@ -71,6 +72,8 @@ if ($pdo) {
       box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
       transition: transform 0.2s;
       cursor: pointer;
+      width: 180px;
+      margin: 0 auto;
     }
 
     .product-card:hover {

--- a/userSide/PRODUCT/cakes.php
+++ b/userSide/PRODUCT/cakes.php
@@ -60,6 +60,7 @@ if ($pdo) {
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 25px;
       padding: 20px 40px;
+      justify-content: center;
     }
 
     .product-card {
@@ -71,6 +72,8 @@ if ($pdo) {
       box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
       transition: transform 0.2s;
       cursor: pointer;
+      width: 180px;
+      margin: 0 auto;
     }
 
     .product-card:hover {

--- a/userSide/PRODUCT/pastry.php
+++ b/userSide/PRODUCT/pastry.php
@@ -61,6 +61,7 @@ if ($pdo) {
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: 25px;
       padding: 20px 40px;
+      justify-content: center;
     }
 
     .product-card {
@@ -72,6 +73,8 @@ if ($pdo) {
       box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
       transition: transform 0.2s;
       cursor: pointer;
+      width: 180px;
+      margin: 0 auto;
     }
 
     .product-card:hover {


### PR DESCRIPTION
## Summary
- keep product cards at consistent 180px width
- center product grids on bread, cakes, and pastry pages

## Testing
- `php -l userSide/PRODUCT/bread.php && php -l userSide/PRODUCT/cakes.php && php -l userSide/PRODUCT/pastry.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c0e4b448324ba616ed0fd9bf37a