### PR TITLE
docs: update folder structure references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ deliveries while administrators manage the catalogue and fulfilment.
 - `Database/` – SQL dump (`cindys_bakeshop.sql`) for database schema and sample data
 - `PHP/` – reusable PHP scripts that implement database functions
 - `adminSide/` – administrator dashboard pages
-- `user-cindysbakeshop/` – customer‑facing pages
-- `Admin Cindys/`, `UpdatedUser/`, `UpdatedUser1/` – legacy/alternate versions kept for reference
+- `userSide/` – customer‑facing pages
+- `user_faces/` – uploaded user face images
+- `vendor/` – Composer dependencies
 
 ## Database Schema Summary
 The SQL dump defines the following tables:
@@ -67,7 +68,7 @@ development server:
 ```sh
 php -S localhost:8000
 ```
-- Browse the customer-facing site at `http://localhost:8000/user-cindysbakeshop`.
+- Browse the customer-facing site at `http://localhost:8000/userSide`.
 - Access the admin dashboard at `http://localhost:8000/adminSide`.
 
 ## Firebase Configuration


### PR DESCRIPTION
## Summary
- update README directory structure to reference `userSide`, `user_faces`, and `vendor`
- remove links to deleted `user-cindysbakeshop` and legacy directories
- adjust local run instructions to reflect new customer-facing path

## Testing
- `markdownlint README.md` *(fails: command not found)*
- `npm install -g markdownlint-cli` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aefad837ec83249f788e3b639aff71