### PR TITLE
Use lowercase table names in SQL queries

### DIFF
--- a/PHP/blacklist_functions.php
+++ b/PHP/blacklist_functions.php
@@ -2,7 +2,7 @@
 // 1) Add a user/IP to blacklist
 function addBlacklist($pdo, $userId, $reason, $ipAddress) {
     $stmt = $pdo->prepare("
-        INSERT INTO Blacklist (User_ID, Blacklist_reason, IP_Address)
+        INSERT INTO blacklist (User_ID, Blacklist_reason, IP_Address)
         VALUES (:user_id, :reason, :ip_address)
     ");
 
@@ -17,14 +17,14 @@ function addBlacklist($pdo, $userId, $reason, $ipAddress) {
 
 // 2) Get all blacklist entries
 function getAllBlacklist($pdo) {
-    $stmt = $pdo->query("SELECT * FROM Blacklist");
+    $stmt = $pdo->query("SELECT * FROM blacklist");
     return $stmt->fetchAll();
 }
 
 // 3) Get blacklist entries for a specific User_ID
 function getBlacklistByUserId($pdo, $userId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Blacklist
+        SELECT * FROM blacklist
         WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
@@ -34,7 +34,7 @@ function getBlacklistByUserId($pdo, $userId) {
 // 4) Get blacklist entries for a specific IP address
 function getBlacklistByIp($pdo, $ipAddress) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Blacklist
+        SELECT * FROM blacklist
         WHERE IP_Address = :ip_address
     ");
     $stmt->execute([':ip_address' => $ipAddress]);
@@ -44,7 +44,7 @@ function getBlacklistByIp($pdo, $ipAddress) {
 // 5) Remove a blacklist entry by Blacklist_ID
 function deleteBlacklistById($pdo, $blacklistId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Blacklist
+        DELETE FROM blacklist
         WHERE Blacklist_ID = :blacklist_id
     ");
     $stmt->execute([':blacklist_id' => $blacklistId]);
@@ -54,7 +54,7 @@ function deleteBlacklistById($pdo, $blacklistId) {
 // 6) Remove all blacklist entries for a specific User_ID
 function deleteBlacklistByUserId($pdo, $userId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Blacklist
+        DELETE FROM blacklist
         WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
@@ -64,7 +64,7 @@ function deleteBlacklistByUserId($pdo, $userId) {
 // 7) Check if a specific User_ID is blacklisted
 function isUserBlacklisted($pdo, $userId) {
     $stmt = $pdo->prepare("
-        SELECT COUNT(*) FROM Blacklist WHERE User_ID = :user_id
+        SELECT COUNT(*) FROM blacklist WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
     return $stmt->fetchColumn() > 0;
@@ -73,7 +73,7 @@ function isUserBlacklisted($pdo, $userId) {
 // 8) Check if an IP address is blacklisted
 function isIpBlacklisted($pdo, $ipAddress) {
     $stmt = $pdo->prepare("
-        SELECT COUNT(*) FROM Blacklist WHERE IP_Address = :ip_address
+        SELECT COUNT(*) FROM blacklist WHERE IP_Address = :ip_address
     ");
     $stmt->execute([':ip_address' => $ipAddress]);
     return $stmt->fetchColumn() > 0;

--- a/PHP/delivery_functions.php
+++ b/PHP/delivery_functions.php
@@ -2,7 +2,7 @@
 // 1) Add delivery info for an order
 function addDelivery($pdo, $orderId, $status, $deliveryDate, $deliveryPersonnel) {
     $stmt = $pdo->prepare("
-        INSERT INTO Delivery (Order_ID, Status, Delivery_Date, Delivery_Personnel)
+        INSERT INTO delivery (Order_ID, Status, Delivery_Date, Delivery_Personnel)
         VALUES (:order_id, :status, :delivery_date, :delivery_personnel)
     ");
     $stmt->execute([
@@ -16,14 +16,14 @@ function addDelivery($pdo, $orderId, $status, $deliveryDate, $deliveryPersonnel)
 
 // 2) Get all deliveries
 function getAllDeliveries($pdo) {
-    $stmt = $pdo->query("SELECT * FROM Delivery");
+    $stmt = $pdo->query("SELECT * FROM delivery");
     return $stmt->fetchAll();
 }
 
 // 3) Get delivery info by Order_ID
 function getDeliveryByOrderId($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Delivery WHERE Order_ID = :order_id
+        SELECT * FROM delivery WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->fetchAll();
@@ -32,7 +32,7 @@ function getDeliveryByOrderId($pdo, $orderId) {
 // 4) Get delivery by Delivery_ID
 function getDeliveryById($pdo, $deliveryId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Delivery WHERE Delivery_ID = :delivery_id
+        SELECT * FROM delivery WHERE Delivery_ID = :delivery_id
     ");
     $stmt->execute([':delivery_id' => $deliveryId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -41,7 +41,7 @@ function getDeliveryById($pdo, $deliveryId) {
 // 5) Update delivery details (status, date, personnel)
 function updateDelivery($pdo, $deliveryId, $status, $deliveryDate, $deliveryPersonnel) {
     $stmt = $pdo->prepare("
-        UPDATE Delivery
+        UPDATE delivery
         SET Status = :status,
             Delivery_Date = :delivery_date,
             Delivery_Personnel = :delivery_personnel
@@ -59,7 +59,7 @@ function updateDelivery($pdo, $deliveryId, $status, $deliveryDate, $deliveryPers
 // 6) Delete delivery by Delivery_ID
 function deleteDeliveryById($pdo, $deliveryId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Delivery WHERE Delivery_ID = :delivery_id
+        DELETE FROM delivery WHERE Delivery_ID = :delivery_id
     ");
     $stmt->execute([':delivery_id' => $deliveryId]);
     return $stmt->rowCount();
@@ -68,7 +68,7 @@ function deleteDeliveryById($pdo, $deliveryId) {
 // 7) Get deliveries by status (e.g., all Pending)
 function getDeliveriesByStatus($pdo, $status) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Delivery WHERE Status = :status
+        SELECT * FROM delivery WHERE Status = :status
     ");
     $stmt->execute([':status' => $status]);
     return $stmt->fetchAll();
@@ -77,7 +77,7 @@ function getDeliveriesByStatus($pdo, $status) {
 // 8) Get deliveries by personnel
 function getDeliveriesByPersonnel($pdo, $personnel) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Delivery WHERE Delivery_Personnel = :personnel
+        SELECT * FROM delivery WHERE Delivery_Personnel = :personnel
     ");
     $stmt->execute([':personnel' => $personnel]);
     return $stmt->fetchAll();

--- a/PHP/delivery_personnel_functions.php
+++ b/PHP/delivery_personnel_functions.php
@@ -2,7 +2,7 @@
 // 1) Add delivery personnel
 function addDeliveryPersonnel($pdo, $userId) {
     $stmt = $pdo->prepare("
-        INSERT INTO Delivery_Personnel (User_ID)
+        INSERT INTO delivery_personnel (User_ID)
         VALUES (:user_id)
     ");
     $stmt->execute([':user_id' => $userId]);
@@ -11,14 +11,14 @@ function addDeliveryPersonnel($pdo, $userId) {
 
 // 2) Get all delivery personnel
 function getAllDeliveryPersonnel($pdo) {
-    $stmt = $pdo->query("SELECT * FROM Delivery_Personnel");
+    $stmt = $pdo->query("SELECT * FROM delivery_personnel");
     return $stmt->fetchAll();
 }
 
 // 3) Get delivery personnel by ID
 function getDeliveryPersonnelById($pdo, $personnelId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Delivery_Personnel WHERE Delivery_Personnel_ID = :personnel_id
+        SELECT * FROM delivery_personnel WHERE Delivery_Personnel_ID = :personnel_id
     ");
     $stmt->execute([':personnel_id' => $personnelId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -27,7 +27,7 @@ function getDeliveryPersonnelById($pdo, $personnelId) {
 // 4) Get delivery personnel by User_ID
 function getDeliveryPersonnelByUserId($pdo, $userId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Delivery_Personnel WHERE User_ID = :user_id
+        SELECT * FROM delivery_personnel WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -36,7 +36,7 @@ function getDeliveryPersonnelByUserId($pdo, $userId) {
 // 5) Delete delivery personnel by ID
 function deleteDeliveryPersonnelById($pdo, $personnelId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Delivery_Personnel WHERE Delivery_Personnel_ID = :personnel_id
+        DELETE FROM delivery_personnel WHERE Delivery_Personnel_ID = :personnel_id
     ");
     $stmt->execute([':personnel_id' => $personnelId]);
     return $stmt->rowCount();
@@ -45,7 +45,7 @@ function deleteDeliveryPersonnelById($pdo, $personnelId) {
 // 6) Delete delivery personnel by User_ID
 function deleteDeliveryPersonnelByUserId($pdo, $userId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Delivery_Personnel WHERE User_ID = :user_id
+        DELETE FROM delivery_personnel WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
     return $stmt->rowCount();

--- a/PHP/inventory_functions.php
+++ b/PHP/inventory_functions.php
@@ -2,7 +2,7 @@
 // 1) Add inventory entry for a product
 function addInventory($pdo, $productId, $stockQuantity) {
     $stmt = $pdo->prepare("
-        INSERT INTO Inventory (Product_ID, Stock_Quantity)
+        INSERT INTO inventory (Product_ID, Stock_Quantity)
         VALUES (:product_id, :stock_quantity)
     ");
     $stmt->execute([
@@ -15,7 +15,7 @@ function addInventory($pdo, $productId, $stockQuantity) {
 // 2) Get inventory record by Product_ID
 function getInventoryByProductId($pdo, $productId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Inventory WHERE Product_ID = :product_id
+        SELECT * FROM inventory WHERE Product_ID = :product_id
     ");
     $stmt->execute([':product_id' => $productId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -23,7 +23,7 @@ function getInventoryByProductId($pdo, $productId) {
 
 // 3) Get all inventory records
 function getAllInventory($pdo) {
-    $stmt = $pdo->query("SELECT * FROM Inventory");
+    $stmt = $pdo->query("SELECT * FROM inventory");
     return $stmt->fetchAll();
 }
 
@@ -31,8 +31,8 @@ function getAllInventory($pdo) {
 function getInventoryWithProducts($pdo) {
     $stmt = $pdo->query(
         "SELECT p.Product_ID, p.Name, p.Category, i.Stock_Quantity\n" .
-        "FROM Inventory i\n" .
-        "JOIN Product p ON i.Product_ID = p.Product_ID"
+        "FROM inventory i\n" .
+        "JOIN product p ON i.Product_ID = p.Product_ID"
     );
     return $stmt->fetchAll();
 }
@@ -40,7 +40,7 @@ function getInventoryWithProducts($pdo) {
 // 4) Update stock quantity for a product
 function updateInventoryStock($pdo, $productId, $stockQuantity) {
     $stmt = $pdo->prepare("
-        UPDATE Inventory
+        UPDATE inventory
         SET Stock_Quantity = :stock_quantity
         WHERE Product_ID = :product_id
     ");
@@ -54,7 +54,7 @@ function updateInventoryStock($pdo, $productId, $stockQuantity) {
 // 5) Adjust stock quantity (+/-)
 function adjustInventoryStock($pdo, $productId, $quantityChange) {
     $stmt = $pdo->prepare("
-        UPDATE Inventory
+        UPDATE inventory
         SET Stock_Quantity = Stock_Quantity + :quantity_change
         WHERE Product_ID = :product_id
     ");
@@ -68,7 +68,7 @@ function adjustInventoryStock($pdo, $productId, $quantityChange) {
 // 6) Delete an inventory record by Product_ID
 function deleteInventoryByProductId($pdo, $productId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Inventory WHERE Product_ID = :product_id
+        DELETE FROM inventory WHERE Product_ID = :product_id
     ");
     $stmt->execute([':product_id' => $productId]);
     return $stmt->rowCount();

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -58,7 +58,7 @@ switch ($action) {
         $orderId = addOrder($pdo, $userId, date('Y-m-d'), 'Pending');
         $total = 0;
         foreach ($items as $it) {
-            $stmt = $pdo->prepare('SELECT Price FROM Product WHERE Product_ID = :id');
+            $stmt = $pdo->prepare('SELECT Price FROM product WHERE Product_ID = :id');
             $stmt->execute([':id' => $it['product_id']]);
             $price = $stmt->fetchColumn();
             $subtotal = $price * $it['quantity'];
@@ -85,10 +85,10 @@ switch ($action) {
         $orderId = (int)($_GET['order_id'] ?? 0);
         $order = getOrderById($pdo, $orderId);
         $user = $order ? getUserById($pdo, $order['User_ID']) : null;
-        $stmt = $pdo->prepare('SELECT oi.Quantity, oi.Subtotal, p.Name FROM Order_Item oi JOIN Product p ON oi.Product_ID = p.Product_ID WHERE oi.Order_ID = :order_id');
+        $stmt = $pdo->prepare('SELECT oi.Quantity, oi.Subtotal, p.Name FROM order_item oi JOIN product p ON oi.Product_ID = p.Product_ID WHERE oi.Order_ID = :order_id');
         $stmt->execute([':order_id' => $orderId]);
         $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        $stmt = $pdo->prepare('SELECT Payment_Method, Payment_Status, Amount_Paid, Reference_Number FROM Transaction WHERE Order_ID = :order_id');
+        $stmt = $pdo->prepare('SELECT Payment_Method, Payment_Status, Amount_Paid, Reference_Number FROM transaction WHERE Order_ID = :order_id');
         $stmt->execute([':order_id' => $orderId]);
         $transaction = $stmt->fetch(PDO::FETCH_ASSOC);
         echo json_encode(['order' => $order, 'user' => $user, 'items' => $items, 'transaction' => $transaction]);

--- a/PHP/order_cancellation_functions.php
+++ b/PHP/order_cancellation_functions.php
@@ -20,7 +20,7 @@ function getAllOrderCancellations($pdo) {
     $stmt = $pdo->query(
         "SELECT oc.*, u.Name AS Customer
          FROM order_cancellation oc
-         LEFT JOIN User u ON oc.User_ID = u.User_ID"
+         LEFT JOIN user u ON oc.User_ID = u.User_ID"
     );
     return $stmt->fetchAll();
 }

--- a/PHP/order_functions.php
+++ b/PHP/order_functions.php
@@ -2,7 +2,7 @@
 // 1) Create a new order
 function addOrder($pdo, $userId, $orderDate, $status) {
     $stmt = $pdo->prepare("
-        INSERT INTO `Order` (User_ID, Order_Date, Status)
+        INSERT INTO `order` (User_ID, Order_Date, Status)
         VALUES (:user_id, :order_date, :status)
     ");
     $stmt->execute([
@@ -15,7 +15,7 @@ function addOrder($pdo, $userId, $orderDate, $status) {
 
 // 2) Get all orders
 function getAllOrders($pdo) {
-    $stmt = $pdo->query("SELECT * FROM `Order`");
+    $stmt = $pdo->query("SELECT * FROM `order`");
     return $stmt->fetchAll();
 }
 
@@ -27,9 +27,9 @@ function getOrdersByUserId($pdo, $userId) {
                o.Order_Date,
                o.Status,
                MIN(p.Image_Path) AS Image_Path
-        FROM `Order` o
-        LEFT JOIN Order_Item oi ON o.Order_ID = oi.Order_ID
-        LEFT JOIN Product p ON oi.Product_ID = p.Product_ID
+        FROM `order` o
+        LEFT JOIN order_item oi ON o.Order_ID = oi.Order_ID
+        LEFT JOIN product p ON oi.Product_ID = p.Product_ID
         WHERE o.User_ID = :user_id
         GROUP BY o.Order_ID, o.User_ID, o.Order_Date, o.Status
     ");
@@ -40,7 +40,7 @@ function getOrdersByUserId($pdo, $userId) {
 // 4) Get a single order by ID
 function getOrderById($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM `Order` WHERE Order_ID = :order_id
+        SELECT * FROM `order` WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -49,7 +49,7 @@ function getOrderById($pdo, $orderId) {
 // 5) Update order status
 function updateOrderStatus($pdo, $orderId, $status) {
     $stmt = $pdo->prepare("
-        UPDATE `Order`
+        UPDATE `order`
         SET Status = :status
         WHERE Order_ID = :order_id
     ");
@@ -63,7 +63,7 @@ function updateOrderStatus($pdo, $orderId, $status) {
 // 6) Delete an order by ID
 function deleteOrderById($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        DELETE FROM `Order` WHERE Order_ID = :order_id
+        DELETE FROM `order` WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->rowCount();
@@ -71,14 +71,14 @@ function deleteOrderById($pdo, $orderId) {
 
 // 7) Count total orders
 function countOrders($pdo) {
-    $stmt = $pdo->query("SELECT COUNT(*) FROM `Order`");
+    $stmt = $pdo->query("SELECT COUNT(*) FROM `order`");
     return $stmt->fetchColumn();
 }
 
 // 8) Get orders by status
 function getOrdersByStatus($pdo, $status) {
     $stmt = $pdo->prepare("
-        SELECT * FROM `Order` WHERE Status = :status
+        SELECT * FROM `order` WHERE Status = :status
     ");
     $stmt->execute([':status' => $status]);
     return $stmt->fetchAll();

--- a/PHP/order_item_functions.php
+++ b/PHP/order_item_functions.php
@@ -2,7 +2,7 @@
 // 1) Add an order item
 function addOrderItem($pdo, $orderId, $productId, $quantity, $subtotal) {
     $stmt = $pdo->prepare("
-        INSERT INTO Order_Item (Order_ID, Product_ID, Quantity, Subtotal)
+        INSERT INTO order_item (Order_ID, Product_ID, Quantity, Subtotal)
         VALUES (:order_id, :product_id, :quantity, :subtotal)
     ");
     $stmt->execute([
@@ -18,7 +18,7 @@ function addOrderItem($pdo, $orderId, $productId, $quantity, $subtotal) {
 function getOrderItemsByOrderId($pdo, $orderId) {
     $stmt = $pdo->prepare("
         SELECT oi.*, p.Name
-        FROM Order_Item oi
+        FROM order_item oi
         JOIN product p ON oi.Product_ID = p.Product_ID
         WHERE oi.Order_ID = :order_id
     ");
@@ -29,7 +29,7 @@ function getOrderItemsByOrderId($pdo, $orderId) {
 // 3) Get all order items for a product
 function getOrderItemsByProductId($pdo, $productId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Order_Item WHERE Product_ID = :product_id
+        SELECT * FROM order_item WHERE Product_ID = :product_id
     ");
     $stmt->execute([':product_id' => $productId]);
     return $stmt->fetchAll();
@@ -38,7 +38,7 @@ function getOrderItemsByProductId($pdo, $productId) {
 // 4) Get a single order item by ID
 function getOrderItemById($pdo, $orderItemId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Order_Item WHERE Order_Item_ID = :order_item_id
+        SELECT * FROM order_item WHERE Order_Item_ID = :order_item_id
     ");
     $stmt->execute([':order_item_id' => $orderItemId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -47,7 +47,7 @@ function getOrderItemById($pdo, $orderItemId) {
 // 5) Update quantity and subtotal of an order item
 function updateOrderItem($pdo, $orderItemId, $quantity, $subtotal) {
     $stmt = $pdo->prepare("
-        UPDATE Order_Item
+        UPDATE order_item
         SET Quantity = :quantity,
             Subtotal = :subtotal
         WHERE Order_Item_ID = :order_item_id
@@ -63,7 +63,7 @@ function updateOrderItem($pdo, $orderItemId, $quantity, $subtotal) {
 // 6) Delete an order item by ID
 function deleteOrderItemById($pdo, $orderItemId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Order_Item WHERE Order_Item_ID = :order_item_id
+        DELETE FROM order_item WHERE Order_Item_ID = :order_item_id
     ");
     $stmt->execute([':order_item_id' => $orderItemId]);
     return $stmt->rowCount();
@@ -72,7 +72,7 @@ function deleteOrderItemById($pdo, $orderItemId) {
 // 7) Delete all order items for an order
 function deleteOrderItemsByOrderId($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Order_Item WHERE Order_ID = :order_id
+        DELETE FROM order_item WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->rowCount();
@@ -81,7 +81,7 @@ function deleteOrderItemsByOrderId($pdo, $orderId) {
 // 8) Calculate total for an order by summing its items
 function calculateOrderTotal($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        SELECT SUM(Subtotal) FROM Order_Item WHERE Order_ID = :order_id
+        SELECT SUM(Subtotal) FROM order_item WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->fetchColumn();

--- a/PHP/store_staff_functions.php
+++ b/PHP/store_staff_functions.php
@@ -2,7 +2,7 @@
 // 1) Add a store staff member
 function addStoreStaff($pdo, $userId) {
     $stmt = $pdo->prepare("
-        INSERT INTO Store_Staff (User_ID)
+        INSERT INTO store_staff (User_ID)
         VALUES (:user_id)
     ");
     $stmt->execute([':user_id' => $userId]);
@@ -11,14 +11,14 @@ function addStoreStaff($pdo, $userId) {
 
 // 2) Get all store staff
 function getAllStoreStaff($pdo) {
-    $stmt = $pdo->query("SELECT * FROM Store_Staff");
+    $stmt = $pdo->query("SELECT * FROM store_staff");
     return $stmt->fetchAll();
 }
 
 // 3) Get store staff by ID
 function getStoreStaffById($pdo, $staffId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Store_Staff WHERE Store_Staff_ID = :staff_id
+        SELECT * FROM store_staff WHERE Store_Staff_ID = :staff_id
     ");
     $stmt->execute([':staff_id' => $staffId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -27,7 +27,7 @@ function getStoreStaffById($pdo, $staffId) {
 // 4) Get store staff by User_ID
 function getStoreStaffByUserId($pdo, $userId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Store_Staff WHERE User_ID = :user_id
+        SELECT * FROM store_staff WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -36,7 +36,7 @@ function getStoreStaffByUserId($pdo, $userId) {
 // 5) Delete store staff by Store_Staff_ID
 function deleteStoreStaffById($pdo, $staffId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Store_Staff WHERE Store_Staff_ID = :staff_id
+        DELETE FROM store_staff WHERE Store_Staff_ID = :staff_id
     ");
     $stmt->execute([':staff_id' => $staffId]);
     return $stmt->rowCount();
@@ -45,7 +45,7 @@ function deleteStoreStaffById($pdo, $staffId) {
 // 6) Delete store staff by User_ID
 function deleteStoreStaffByUserId($pdo, $userId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Store_Staff WHERE User_ID = :user_id
+        DELETE FROM store_staff WHERE User_ID = :user_id
     ");
     $stmt->execute([':user_id' => $userId]);
     return $stmt->rowCount();

--- a/PHP/transaction_functions.php
+++ b/PHP/transaction_functions.php
@@ -2,7 +2,7 @@
 // 1) Add a transaction
 function addTransaction($pdo, $orderId, $paymentMethod, $paymentStatus, $paymentDate, $amountPaid, $referenceNumber) {
     $stmt = $pdo->prepare("
-        INSERT INTO Transaction (Order_ID, Payment_Method, Payment_Status, Payment_Date, Amount_Paid, Reference_Number)
+        INSERT INTO transaction (Order_ID, Payment_Method, Payment_Status, Payment_Date, Amount_Paid, Reference_Number)
         VALUES (:order_id, :payment_method, :payment_status, :payment_date, :amount_paid, :reference_number)
     ");
     $stmt->execute([
@@ -18,14 +18,14 @@ function addTransaction($pdo, $orderId, $paymentMethod, $paymentStatus, $payment
 
 // 2) Get all transactions
 function getAllTransactions($pdo) {
-    $stmt = $pdo->query("SELECT * FROM Transaction");
+    $stmt = $pdo->query("SELECT * FROM transaction");
     return $stmt->fetchAll();
 }
 
 // 3) Get all transactions for an Order_ID
 function getTransactionsByOrderId($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Transaction WHERE Order_ID = :order_id
+        SELECT * FROM transaction WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->fetchAll();
@@ -34,7 +34,7 @@ function getTransactionsByOrderId($pdo, $orderId) {
 // 4) Get a single transaction by ID
 function getTransactionById($pdo, $transactionId) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Transaction WHERE Transaction_ID = :transaction_id
+        SELECT * FROM transaction WHERE Transaction_ID = :transaction_id
     ");
     $stmt->execute([':transaction_id' => $transactionId]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
@@ -43,7 +43,7 @@ function getTransactionById($pdo, $transactionId) {
 // 5) Update payment status
 function updateTransactionStatus($pdo, $transactionId, $paymentStatus) {
     $stmt = $pdo->prepare("
-        UPDATE Transaction
+        UPDATE transaction
         SET Payment_Status = :payment_status
         WHERE Transaction_ID = :transaction_id
     ");
@@ -57,7 +57,7 @@ function updateTransactionStatus($pdo, $transactionId, $paymentStatus) {
 // 6) Delete a transaction by ID
 function deleteTransactionById($pdo, $transactionId) {
     $stmt = $pdo->prepare("
-        DELETE FROM Transaction WHERE Transaction_ID = :transaction_id
+        DELETE FROM transaction WHERE Transaction_ID = :transaction_id
     ");
     $stmt->execute([':transaction_id' => $transactionId]);
     return $stmt->rowCount();
@@ -66,7 +66,7 @@ function deleteTransactionById($pdo, $transactionId) {
 // 7) Get transactions by payment method
 function getTransactionsByMethod($pdo, $paymentMethod) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Transaction WHERE Payment_Method = :payment_method
+        SELECT * FROM transaction WHERE Payment_Method = :payment_method
     ");
     $stmt->execute([':payment_method' => $paymentMethod]);
     return $stmt->fetchAll();
@@ -75,7 +75,7 @@ function getTransactionsByMethod($pdo, $paymentMethod) {
 // 8) Get transactions by payment status
 function getTransactionsByStatus($pdo, $paymentStatus) {
     $stmt = $pdo->prepare("
-        SELECT * FROM Transaction WHERE Payment_Status = :payment_status
+        SELECT * FROM transaction WHERE Payment_Status = :payment_status
     ");
     $stmt->execute([':payment_status' => $paymentStatus]);
     return $stmt->fetchAll();
@@ -84,7 +84,7 @@ function getTransactionsByStatus($pdo, $paymentStatus) {
 // 9) Calculate total paid for an Order_ID
 function getTotalPaidByOrderId($pdo, $orderId) {
     $stmt = $pdo->prepare("
-        SELECT SUM(Amount_Paid) FROM Transaction WHERE Order_ID = :order_id
+        SELECT SUM(Amount_Paid) FROM transaction WHERE Order_ID = :order_id
     ");
     $stmt->execute([':order_id' => $orderId]);
     return $stmt->fetchColumn();

--- a/PHP/user_api.php
+++ b/PHP/user_api.php
@@ -46,7 +46,7 @@ switch ($action) {
             $userId = (int)($_POST['user_id'] ?? 0);
         }
         $path = $_POST['face_image_path'] ?? '';
-        $stmt = $pdo->prepare('UPDATE User SET Face_Image_Path = :path WHERE User_ID = :id');
+        $stmt = $pdo->prepare('UPDATE user SET Face_Image_Path = :path WHERE User_ID = :id');
         $stmt->execute([':path' => $path, ':id' => $userId]);
         echo json_encode(['updated' => $stmt->rowCount()]);
         break;
@@ -119,7 +119,7 @@ switch ($action) {
             ':name' => $fullName,
             ':id' => $user['User_ID']
         ];
-        $sql = 'UPDATE User SET Name = :name';
+        $sql = 'UPDATE user SET Name = :name';
 
         if ($password) {
             $hashed = password_hash($password, PASSWORD_DEFAULT);

--- a/PHP/user_functions.php
+++ b/PHP/user_functions.php
@@ -1,6 +1,6 @@
 <?php
     function getAllUsers($pdo) {
-        $stmt = $pdo->query("SELECT * FROM User");
+        $stmt = $pdo->query("SELECT * FROM user");
         return $stmt->fetchAll();
     }
 
@@ -9,7 +9,7 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
         $hashed_password = password_hash($password, PASSWORD_DEFAULT);
 
         // Prepare SQL query
-    $stmt = $pdo->prepare("INSERT INTO User (Name, Email, Password, Address, Warning_Count, Face_Image_Path)
+    $stmt = $pdo->prepare("INSERT INTO user (Name, Email, Password, Address, Warning_Count, Face_Image_Path)
                             VALUES (:name, :email, :password, :address, :warning_count, :face_image_path)");
 
         // Execute with data
@@ -26,20 +26,20 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
     }
 
     function deleteUserById($pdo, $userId) {
-        $stmt = $pdo->prepare("DELETE FROM User WHERE User_ID = :user_id");
+        $stmt = $pdo->prepare("DELETE FROM user WHERE User_ID = :user_id");
         $stmt->execute([':user_id' => $userId]);
         return $stmt->rowCount(); // returns number of rows deleted (0 or 1)
     }
 
     function deleteAllUsers($pdo) {
-        $stmt = $pdo->prepare("DELETE FROM User");
+        $stmt = $pdo->prepare("DELETE FROM user");
         $stmt->execute();
         return $stmt->rowCount(); // returns number of rows deleted
     }
 
     function updateUserById($pdo, $userId, $name, $email, $address, $warning_count) {
         $stmt = $pdo->prepare("
-            UPDATE User
+            UPDATE user
             SET Name = :name,
                 Email = :email,
                 Address = :address,
@@ -62,7 +62,7 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
         $hashed_password = password_hash($newPassword, PASSWORD_DEFAULT);
 
         $stmt = $pdo->prepare("
-            UPDATE User
+            UPDATE user
             SET Password = :password
             WHERE User_ID = :user_id
         ");
@@ -77,7 +77,7 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
 
     function updateUserNameAddress($pdo, $userId, $name, $address) {
         $stmt = $pdo->prepare("
-            UPDATE User
+            UPDATE user
             SET Name = :name,
                 Address = :address
             WHERE User_ID = :user_id
@@ -93,19 +93,19 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
     }
 
     function getUserById($pdo, $userId) {
-        $stmt = $pdo->prepare("SELECT * FROM User WHERE User_ID = :user_id");
+        $stmt = $pdo->prepare("SELECT * FROM user WHERE User_ID = :user_id");
         $stmt->execute([':user_id' => $userId]);
         return $stmt->fetch(PDO::FETCH_ASSOC); // returns single user or false
     }
 
     function getUserByEmail($pdo, $email) {
-        $stmt = $pdo->prepare("SELECT * FROM User WHERE Email = :email");
+        $stmt = $pdo->prepare("SELECT * FROM user WHERE Email = :email");
         $stmt->execute([':email' => $email]);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 
     function checkEmailExists($pdo, $email) {
-        $stmt = $pdo->prepare("SELECT COUNT(*) FROM User WHERE Email = :email");
+        $stmt = $pdo->prepare("SELECT COUNT(*) FROM user WHERE Email = :email");
         $stmt->execute([':email' => $email]);
         return $stmt->fetchColumn() > 0;
     }
@@ -119,13 +119,13 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
     }
 
     function countUsers($pdo) {
-        $stmt = $pdo->query("SELECT COUNT(*) FROM User");
+        $stmt = $pdo->query("SELECT COUNT(*) FROM user");
         return $stmt->fetchColumn();
     }
 
     function searchUsers($pdo, $keyword) {
         $stmt = $pdo->prepare("
-            SELECT * FROM User
+            SELECT * FROM user
             WHERE Name LIKE :kw OR Email LIKE :kw
         ");
         $stmt->execute([':kw' => "%$keyword%"]);
@@ -134,7 +134,7 @@ function addUser($pdo, $name, $email, $password, $address, $warning_count = 0, $
 
     function incrementWarningCount($pdo, $userId) {
         $stmt = $pdo->prepare("
-            UPDATE User
+            UPDATE user
             SET Warning_Count = Warning_Count + 1
             WHERE User_ID = :user_id
         ");


### PR DESCRIPTION
## Summary
- normalize SQL queries to match lowercase table names (`product`, `order_item`, `transaction`, etc.)
- ensure all PHP database helpers reference lowercase schema definitions

## Testing
- `php -l PHP/blacklist_functions.php PHP/delivery_functions.php PHP/delivery_personnel_functions.php PHP/inventory_functions.php PHP/order_api.php PHP/order_cancellation_functions.php PHP/order_functions.php PHP/order_item_functions.php PHP/store_staff_functions.php PHP/transaction_functions.php PHP/user_api.php PHP/user_functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68aefb3da02883248c77ba4bca0e5cdc