### PR TITLE
Add admin notifications page and API endpoint

### DIFF
--- a/PHP/notification_api.php
+++ b/PHP/notification_api.php
@@ -14,6 +14,20 @@ switch ($action) {
         }
         echo json_encode($notifications);
         break;
+    case 'all':
+    case '':
+        $notifications = getAllNotifications($pdo);
+        $unreadIds = array_column(
+            array_filter($notifications, function ($n) {
+                return $n['Is_Read'] == 0;
+            }),
+            'Notification_ID'
+        );
+        if (!empty($unreadIds)) {
+            markNotificationsAsRead($pdo, $unreadIds);
+        }
+        echo json_encode($notifications);
+        break;
     default:
         http_response_code(400);
         echo json_encode(['error' => 'Invalid action']);

--- a/PHP/notification_api.php
+++ b/PHP/notification_api.php
@@ -1,0 +1,21 @@
+<?php
+require_once 'db_connect.php';
+require_once 'notification_functions.php';
+
+header('Content-Type: application/json');
+$action = $_GET['action'] ?? $_POST['action'] ?? '';
+
+switch ($action) {
+    case 'unread':
+        $notifications = getUnreadNotifications($pdo);
+        $ids = array_column($notifications, 'Notification_ID');
+        if (!empty($ids)) {
+            markNotificationsAsRead($pdo, $ids);
+        }
+        echo json_encode($notifications);
+        break;
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid action']);
+}
+?>

--- a/PHP/notification_functions.php
+++ b/PHP/notification_functions.php
@@ -10,7 +10,18 @@ function addNotification($pdo, $type, $referenceId, $message) {
 }
 
 function getUnreadNotifications($pdo) {
-    $stmt = $pdo->query("SELECT Notification_ID, Type, Reference_ID, Message, Created_At FROM notification WHERE Is_Read = 0 ORDER BY Created_At DESC");
+    $stmt = $pdo->query(
+        "SELECT Notification_ID, Type, Reference_ID, Message, Created_At " .
+        "FROM notification WHERE Is_Read = 0 ORDER BY Created_At DESC"
+    );
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function getAllNotifications($pdo) {
+    $stmt = $pdo->query(
+        "SELECT Notification_ID, Type, Reference_ID, Message, Created_At, Is_Read " .
+        "FROM notification ORDER BY Created_At DESC"
+    );
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 

--- a/PHP/notification_functions.php
+++ b/PHP/notification_functions.php
@@ -1,0 +1,16 @@
+<?php
+function getUnreadNotifications($pdo) {
+    $stmt = $pdo->query("SELECT Notification_ID, Type, Reference_ID, Message, Created_At FROM notification WHERE Is_Read = 0 ORDER BY Created_At DESC");
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function markNotificationsAsRead($pdo, $ids) {
+    if (empty($ids)) {
+        return 0;
+    }
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $stmt = $pdo->prepare("UPDATE notification SET Is_Read = 1 WHERE Notification_ID IN ($placeholders)");
+    $stmt->execute($ids);
+    return $stmt->rowCount();
+}
+?>

--- a/PHP/notification_functions.php
+++ b/PHP/notification_functions.php
@@ -1,4 +1,14 @@
 <?php
+function addNotification($pdo, $type, $referenceId, $message) {
+    $stmt = $pdo->prepare('INSERT INTO notification (Type, Reference_ID, Message) VALUES (:type, :ref, :message)');
+    $stmt->execute([
+        ':type'    => $type,
+        ':ref'     => $referenceId,
+        ':message' => $message
+    ]);
+    return $pdo->lastInsertId();
+}
+
 function getUnreadNotifications($pdo) {
     $stmt = $pdo->query("SELECT Notification_ID, Type, Reference_ID, Message, Created_At FROM notification WHERE Is_Read = 0 ORDER BY Created_At DESC");
     return $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/adminSide/notifications.php
+++ b/adminSide/notifications.php
@@ -1,0 +1,40 @@
+<?php
+$activePage = 'notifications';
+$pageTitle = 'Notifications';
+$headerTitle = 'Notifications';
+$bodyClass = 'dashboard-page';
+include 'header.php';
+?>
+<div class="flex min-h-screen">
+  <?php include $prefix . 'sidebar.php'; ?>
+  <main class="flex-1 p-6 overflow-y-auto">
+    <?php include $prefix . 'topbar.php'; ?>
+    <div class="mt-6">
+      <h2 class="text-lg font-semibold mb-4">Unread Notifications</h2>
+      <ul id="notificationsList" class="bg-white rounded shadow divide-y"></ul>
+    </div>
+  </main>
+</div>
+<script>
+fetch('../PHP/notification_api.php?action=unread')
+  .then(response => response.json())
+  .then(data => {
+    const list = document.getElementById('notificationsList');
+    if (!Array.isArray(data) || data.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'p-4 text-sm text-gray-500';
+      li.textContent = 'No unread notifications.';
+      list.appendChild(li);
+      return;
+    }
+    data.forEach(n => {
+      const li = document.createElement('li');
+      li.className = 'p-4 text-sm hover:bg-gray-50';
+      li.textContent = `${n.Message} (${n.Created_At})`;
+      list.appendChild(li);
+    });
+  })
+  .catch(err => console.error('Error fetching notifications:', err));
+</script>
+</body>
+</html>

--- a/adminSide/notifications.php
+++ b/adminSide/notifications.php
@@ -10,23 +10,23 @@ include 'header.php';
   <main class="flex-1 p-6 overflow-y-auto">
     <?php include $prefix . 'topbar.php'; ?>
     <div class="mt-6">
-      <h2 class="text-lg font-semibold mb-4">Unread Notifications</h2>
+      <h2 class="text-lg font-semibold mb-4">All Notifications</h2>
       <ul id="notificationsList" class="bg-white rounded shadow divide-y"></ul>
     </div>
   </main>
 </div>
 <script>
-fetch('../PHP/notification_api.php?action=unread')
+  fetch('../PHP/notification_api.php?action=all')
   .then(response => response.json())
   .then(data => {
     const list = document.getElementById('notificationsList');
-    if (!Array.isArray(data) || data.length === 0) {
-      const li = document.createElement('li');
-      li.className = 'p-4 text-sm text-gray-500';
-      li.textContent = 'No unread notifications.';
-      list.appendChild(li);
-      return;
-    }
+      if (!Array.isArray(data) || data.length === 0) {
+        const li = document.createElement('li');
+        li.className = 'p-4 text-sm text-gray-500';
+        li.textContent = 'No notifications.';
+        list.appendChild(li);
+        return;
+      }
     data.forEach(n => {
       const li = document.createElement('li');
       li.className = 'p-4 text-sm hover:bg-gray-50';

--- a/adminSide/sidebar.php
+++ b/adminSide/sidebar.php
@@ -33,6 +33,7 @@ $prefix = str_repeat('../', $depth);
     </div>
 
     <a href="<?= $prefix ?>dashboard/user.php" class="flex items-center gap-2 p-2 rounded sidebar-link">👥 Users</a>
+    <a href="<?= $prefix ?>notifications.php" class="flex items-center gap-2 p-2 rounded <?php echo $activePage === 'notifications' ? 'bg-gray-200 font-semibold' : 'sidebar-link'; ?>">🔔 Notifications</a>
 
     <!-- Reports -->
     <div class="menu">


### PR DESCRIPTION
## Summary
- Add `notification_functions.php` and `notification_api.php` to fetch unread notifications and mark them as read
- Create `adminSide/notifications.php` for admins to view notifications
- Update sidebar with navigation link to notifications page

## Testing
- `php -l PHP/notification_functions.php`
- `php -l PHP/notification_api.php`
- `php -l adminSide/notifications.php`
- `php -l adminSide/sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_68af0a9705208324b8dea7e5e3d62502