### PR TITLE
Add debug logging for admin notifications

### DIFF
--- a/adminSide/Reports/FinanceSalesReport.php
+++ b/adminSide/Reports/FinanceSalesReport.php
@@ -107,20 +107,29 @@ include '../header.php';
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.29/jspdf.plugin.autotable.min.js"></script>
-  <script>
-    const notifications = [
-      "⚠️ Low Stock: Chocolate Cake (2 left)",
-      "🛒 New Order #1245 from Bulacan",
-      "💬 New customer feedback received"
-    ];
+    <script>
+      console.log('Initializing finance report notifications');
+      const notifications = [
+        "⚠️ Low Stock: Chocolate Cake (2 left)",
+        "🛒 New Order #1245 from Bulacan",
+        "💬 New customer feedback received"
+      ];
 
-    const notifList = document.getElementById("notifList");
-    notifications.forEach(note => {
-      const li = document.createElement("li");
-      li.className = "px-4 py-2 hover:bg-gray-100 cursor-pointer";
-      li.textContent = note;
-      notifList.appendChild(li);
-    });
+      const notifList = document.getElementById("notifList");
+      if (!notifList) {
+        console.warn('notifList element not found in finance report');
+      } else {
+        console.log('notifList element found in finance report');
+      }
+
+      notifications.forEach((note, index) => {
+        console.log(`Appending notification ${index + 1}:`, note);
+        const li = document.createElement("li");
+        li.className = "px-4 py-2 hover:bg-gray-100 cursor-pointer";
+        li.textContent = note;
+        notifList.appendChild(li);
+      });
+      console.log('Finished populating finance report notifications');
 
     const ctx = document.getElementById('salesChart').getContext('2d');
     const salesChart = new Chart(ctx, {

--- a/adminSide/dashboard/admin_dash.php
+++ b/adminSide/dashboard/admin_dash.php
@@ -89,20 +89,29 @@ include '../header.php';
   </div>
 
   <!-- Script Section -->
-  <script>
-    const notifications = [
-      "⚠️ Low Stock: Chocolate Cake (2 left)",
-      "🛒 New Order #1245 from Bulacan",
-      "💬 New customer feedback received"
-    ];
+    <script>
+      console.log('Initializing dashboard notifications');
+      const notifications = [
+        "⚠️ Low Stock: Chocolate Cake (2 left)",
+        "🛒 New Order #1245 from Bulacan",
+        "💬 New customer feedback received"
+      ];
 
-    const notifList = document.getElementById("notifList");
-    notifications.forEach(note => {
-      const li = document.createElement("li");
-      li.className = "px-4 py-2 hover:bg-gray-100 cursor-pointer";
-      li.textContent = note;
-      notifList.appendChild(li);
-    });
+      const notifList = document.getElementById("notifList");
+      if (!notifList) {
+        console.warn('notifList element not found on dashboard');
+      } else {
+        console.log('notifList element found on dashboard');
+      }
+
+      notifications.forEach((note, index) => {
+        console.log(`Appending notification ${index + 1}:`, note);
+        const li = document.createElement("li");
+        li.className = "px-4 py-2 hover:bg-gray-100 cursor-pointer";
+        li.textContent = note;
+        notifList.appendChild(li);
+      });
+      console.log('Finished populating dashboard notifications');
 
     // Sales filter simulation
     const salesAmount = document.getElementById("salesAmount");

--- a/adminSide/notifications.php
+++ b/adminSide/notifications.php
@@ -16,23 +16,32 @@ include 'header.php';
   </main>
 </div>
 <script>
+  console.log('Fetching all notifications for admin');
   fetch('../PHP/notification_api.php?action=all')
-  .then(response => response.json())
+  .then(response => {
+    console.log('Fetch response received', response);
+    return response.json();
+  })
   .then(data => {
+    console.log('Fetched data:', data);
     const list = document.getElementById('notificationsList');
-      if (!Array.isArray(data) || data.length === 0) {
-        const li = document.createElement('li');
-        li.className = 'p-4 text-sm text-gray-500';
-        li.textContent = 'No notifications.';
-        list.appendChild(li);
-        return;
-      }
-    data.forEach(n => {
+    if (!Array.isArray(data) || data.length === 0) {
+      console.log('No notifications returned from API');
+      const li = document.createElement('li');
+      li.className = 'p-4 text-sm text-gray-500';
+      li.textContent = 'No notifications.';
+      list.appendChild(li);
+      return;
+    }
+    console.log(`Rendering ${data.length} notifications`);
+    data.forEach((n, index) => {
+      console.log(`Adding notification ${index + 1}:`, n);
       const li = document.createElement('li');
       li.className = 'p-4 text-sm hover:bg-gray-50';
       li.textContent = `${n.Message} (${n.Created_At})`;
       list.appendChild(li);
     });
+    console.log('Finished rendering notifications');
   })
   .catch(err => console.error('Error fetching notifications:', err));
 </script>

--- a/adminSide/topbar.php
+++ b/adminSide/topbar.php
@@ -21,16 +21,24 @@ $avatarSrc = $avatarSrc ?? 'https://i.imgur.com/1Q2Z1ZL.png';
   </div>
 </div>
 <script>
+console.log('Topbar notification script initialized');
+
 function toggleDropdown() {
   const dropdown = document.getElementById('notificationDropdown');
+  console.log('toggleDropdown called');
   if (dropdown) {
     dropdown.classList.toggle('hidden');
+    console.log('Dropdown now', dropdown.classList.contains('hidden') ? 'hidden' : 'visible');
+  } else {
+    console.warn('notificationDropdown element not found');
   }
 }
+
 window.addEventListener('click', function (e) {
   const button = document.querySelector('button[onclick="toggleDropdown()"]');
   const dropdown = document.getElementById('notificationDropdown');
   if (button && dropdown && !button.contains(e.target) && !dropdown.contains(e.target)) {
+    console.log('Click outside dropdown detected, hiding notification menu');
     dropdown.classList.add('hidden');
   }
 });


### PR DESCRIPTION
## Summary
- log notification script initialization and dropdown interactions in topbar
- track fetch, rendering, and errors on notifications page
- instrument dashboard and reports pages to log notification dropdown population

## Testing
- `php -l adminSide/topbar.php`
- `php -l adminSide/notifications.php`
- `php -l adminSide/dashboard/admin_dash.php`
- `php -l adminSide/Reports/FinanceSalesReport.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba486f2ba48324b591f2f0e58c4ebf