### PR TITLE
Enable inline order status updates

### DIFF
--- a/PHP/order_functions.php
+++ b/PHP/order_functions.php
@@ -83,4 +83,31 @@ function getOrdersByStatus($pdo, $status) {
     $stmt->execute([':status' => $status]);
     return $stmt->fetchAll();
 }
+
+// --- API Endpoints -------------------------------------------------------
+// Allows this file to handle status updates via AJAX.
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
+    require_once __DIR__ . '/db_connect.php';
+    if (!$pdo) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'message' => 'Database connection failed']);
+        exit;
+    }
+
+    header('Content-Type: application/json');
+    $action = filter_input(INPUT_POST, 'action', FILTER_SANITIZE_SPECIAL_CHARS);
+
+    switch ($action) {
+        case 'updateStatus':
+            $orderId = filter_input(INPUT_POST, 'order_id', FILTER_VALIDATE_INT) ?? 0;
+            $status = filter_input(INPUT_POST, 'status', FILTER_SANITIZE_SPECIAL_CHARS) ?? '';
+            $success = updateOrderStatus($pdo, $orderId, $status) > 0;
+            echo json_encode(['success' => $success]);
+            break;
+        default:
+            echo json_encode(['success' => false, 'message' => 'Invalid action']);
+            break;
+    }
+    exit;
+}
 ?>

--- a/adminSide/ORDERS/ManageOrders.php
+++ b/adminSide/ORDERS/ManageOrders.php
@@ -71,7 +71,13 @@ include '../header.php';
                 <td><?= htmlspecialchars($user['Name'] ?? 'User '.$order['User_ID']); ?></td>
                 <td><?= $itemCount; ?> item<?= $itemCount === 1 ? '' : 's'; ?></td>
                 <td>₱<?= number_format($total ?? 0, 2); ?></td>
-                <td class="<?= $statusClass ?> font-medium"><?= htmlspecialchars($order['Status']); ?></td>
+                <td>
+                  <select class="status-dropdown <?= $statusClass ?> font-medium" data-order-id="<?= $order['Order_ID']; ?>">
+                    <option value="Pending" <?= $status === 'pending' ? 'selected' : '' ?>>Pending</option>
+                    <option value="Shipped" <?= $status === 'shipped' ? 'selected' : '' ?>>Shipped</option>
+                    <option value="Delivered" <?= $status === 'delivered' ? 'selected' : '' ?>>Delivered</option>
+                  </select>
+                </td>
                 <td><a href="OrderDetails.php?order_id=<?= $order['Order_ID']; ?>" class="text-blue-500 hover:underline">View</a></td>
               </tr>
             <?php endforeach; ?>
@@ -146,6 +152,33 @@ include '../header.php';
 
     document.getElementById('startDate').addEventListener('change', applyFilters);
     document.getElementById('endDate').addEventListener('change', applyFilters);
+
+    document.querySelectorAll('.status-dropdown').forEach(select => {
+      select.addEventListener('change', function() {
+        const orderId = this.dataset.orderId;
+        const newStatus = this.value;
+        const fd = new FormData();
+        fd.append('action', 'updateStatus');
+        fd.append('order_id', orderId);
+        fd.append('status', newStatus);
+        fetch('../../PHP/order_functions.php', { method: 'POST', body: fd })
+          .then(r => r.json())
+          .then(data => {
+            if (data.success) {
+              const row = this.closest('tr');
+              row.dataset.status = newStatus.toLowerCase();
+              let statusClass = '';
+              if (newStatus === 'Pending') { statusClass = 'text-yellow-500'; }
+              else if (newStatus === 'Shipped') { statusClass = 'text-blue-500'; }
+              else if (newStatus === 'Delivered') { statusClass = 'text-green-500'; }
+              this.className = 'status-dropdown ' + statusClass + ' font-medium';
+              applyFilters();
+            } else {
+              alert('Failed to update status');
+            }
+          });
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Allow admins to change order status directly in the orders table via a dropdown
- Persist status changes immediately with a new AJAX endpoint in `order_functions.php`

## Testing
- `php -l PHP/order_functions.php`
- `php -l adminSide/ORDERS/ManageOrders.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf048b2be08324a4d37741733db035