### PR TITLE
Send user order confirmation emails

### DIFF
--- a/PHP/email_functions.php
+++ b/PHP/email_functions.php
@@ -58,6 +58,55 @@ function sendAdminEmail(string $subject, string $body): void
 }
 
 /**
+ * Send an email to a specified recipient using Brevo SMTP settings.
+ *
+ * @param string $to
+ * @param string $subject
+ * @param string $body
+ * @return void
+ */
+function sendUserEmail(string $to, string $subject, string $body): void
+{
+    $host = $_ENV['BREVO_SMTP_HOST'] ?? '';
+    $port = (int)($_ENV['BREVO_SMTP_PORT'] ?? 587);
+    $username = $_ENV['BREVO_SMTP_USERNAME'] ?? '';
+    $password = $_ENV['BREVO_SMTP_PASSWORD'] ?? '';
+    $from = $_ENV['BREVO_FROM_EMAIL'] ?? '';
+    $fromName = $_ENV['BREVO_FROM_NAME'] ?? 'Stock Bot';
+
+    if (!$host || !$from || !$to) {
+        error_log('SMTP configuration incomplete.');
+        return;
+    }
+
+    if (!class_exists(PHPMailer::class)) {
+        error_log('PHPMailer library missing. Email not sent.');
+        return;
+    }
+
+    $mail = new PHPMailer(true);
+
+    try {
+        $mail->isSMTP();
+        $mail->Host = $host;
+        $mail->Port = $port;
+        $mail->SMTPAuth = !empty($username);
+        if ($mail->SMTPAuth) {
+            $mail->Username = $username;
+            $mail->Password = $password;
+        }
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+        $mail->setFrom($from, $fromName);
+        $mail->addAddress($to);
+        $mail->Subject = $subject;
+        $mail->Body = $body;
+        $mail->send();
+    } catch (Exception $e) {
+        error_log('Mailer Error: ' . $mail->ErrorInfo);
+    }
+}
+
+/**
  * Send a low-stock notification email using SMTP credentials.
  *
  * @param string $productName
@@ -84,5 +133,20 @@ function sendOrderNotificationEmail(int $orderId, int $userId, float $total): vo
     $subject = 'New Order: #' . $orderId;
     $body = "Order #{$orderId} has been placed by user ID {$userId}. Total amount: {$total}.";
     sendAdminEmail($subject, $body);
+}
+
+/**
+ * Send an order confirmation email to the user.
+ *
+ * @param string $toEmail
+ * @param int    $orderId
+ * @param float  $total
+ * @return void
+ */
+function sendOrderConfirmationEmail(string $toEmail, int $orderId, float $total): void
+{
+    $subject = 'Order Confirmation: #' . $orderId;
+    $body = "Thank you for your order #{$orderId}. Total amount: {$total}.";
+    sendUserEmail($toEmail, $subject, $body);
 }
 ?>

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -43,6 +43,7 @@ switch ($action) {
             $userId = (int)$user['User_ID'];
         } else {
             $userId = (int)($_POST['user_id'] ?? 0);
+            $user = getUserById($pdo, $userId);
         }
         $items = json_decode($_POST['items'] ?? '[]', true);
         $mop   = $_POST['mop'] ?? '';
@@ -86,6 +87,9 @@ switch ($action) {
             deleteCartItemsByCartId($pdo, $cart['Cart_ID']);
         }
         sendOrderNotificationEmail($orderId, $userId, $total);
+        if ($user && isset($user['Email'])) {
+            sendOrderConfirmationEmail($user['Email'], $orderId, $total);
+        }
         addNotification(
             $pdo,
             'order',


### PR DESCRIPTION
## Summary
- add generic user email helper and order confirmation email function
- send confirmation email to the purchasing user when an order is created

## Testing
- `php -l PHP/email_functions.php`
- `php -l PHP/order_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0b7fc7a4832494840849af643e31