### PR TITLE
Add walk-in order tooling and track order source

### DIFF
--- a/Database/add_order_source_columns.sql
+++ b/Database/add_order_source_columns.sql
@@ -1,0 +1,6 @@
+-- Adds Source and Fulfillment_Type tracking to the order table for walk-in support
+ALTER TABLE `order`
+    ADD COLUMN IF NOT EXISTS `Source` ENUM('online','walk-in') NULL DEFAULT 'online' AFTER `Order_Date`,
+    ADD COLUMN IF NOT EXISTS `Fulfillment_Type` ENUM('Delivery','Pick up') NULL DEFAULT 'Delivery' AFTER `Source`,
+    ADD INDEX IF NOT EXISTS `idx_order_source` (`Source`),
+    ADD INDEX IF NOT EXISTS `idx_order_fulfillment` (`Fulfillment_Type`);

--- a/Database/cindys_bakeshop.sql
+++ b/Database/cindys_bakeshop.sql
@@ -83,6 +83,8 @@ CREATE TABLE `order` (
   `Order_ID` int(11) NOT NULL,
   `User_ID` int(11) DEFAULT NULL,
   `Order_Date` date DEFAULT NULL,
+  `Source` enum('online','walk-in') DEFAULT 'online',
+  `Fulfillment_Type` enum('Delivery','Pick up') DEFAULT 'Delivery',
   `Status` enum('Pending','Confirmed','Shipped','Delivered') DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -214,7 +216,9 @@ ALTER TABLE `inventory`
 --
 ALTER TABLE `order`
   ADD PRIMARY KEY (`Order_ID`),
-  ADD KEY `User_ID` (`User_ID`);
+  ADD KEY `User_ID` (`User_ID`),
+  ADD KEY `idx_order_source` (`Source`),
+  ADD KEY `idx_order_fulfillment` (`Fulfillment_Type`);
 
 --
 -- Indexes for table `order_item`

--- a/Database/order_sample_data.sql
+++ b/Database/order_sample_data.sql
@@ -3,10 +3,10 @@ INSERT INTO User (User_ID, Name, Email, Password, Address, Warning_Count) VALUES
     (2, 'Juan Dela Cruz', 'juan@example.com', '$2y$10$abcdefghijklmnopqrstuv', '456 Sample St', 0),
     (3, 'Anna Reyes', 'anna@example.com', '$2y$10$abcdefghijklmnopqrstuv', '789 Sample St', 0);
 
-INSERT INTO `Order` (Order_ID, User_ID, Order_Date, Status) VALUES
-    (1, 1, '2025-07-01', 'Pending'),
-    (2, 2, '2025-07-02', 'Shipped'),
-    (3, 3, '2025-07-03', 'Delivered');
+INSERT INTO `Order` (Order_ID, User_ID, Order_Date, Source, Fulfillment_Type, Status) VALUES
+    (1, 1, '2025-07-01', 'online', 'Delivery', 'Pending'),
+    (2, 2, '2025-07-02', 'online', 'Delivery', 'Shipped'),
+    (3, 3, '2025-07-03', 'online', 'Pick up', 'Delivered');
 
 INSERT INTO Order_Item (Order_Item_ID, Order_ID, Product_ID, Quantity, Subtotal) VALUES
     (1, 1, 23, 1, 699.00),

--- a/PHP/order_api.php
+++ b/PHP/order_api.php
@@ -46,6 +46,8 @@ switch ($action) {
             $user = getUserById($pdo, $userId);
         }
         $items = json_decode($_POST['items'] ?? '[]', true);
+        $orderTypeInput = isset($_POST['order_type']) ? trim($_POST['order_type']) : '';
+        $orderType = in_array($orderTypeInput, ['Delivery', 'Pick up'], true) ? $orderTypeInput : 'Delivery';
         $mop   = $_POST['mop'] ?? '';
 
         foreach ($items as $it) {
@@ -57,7 +59,7 @@ switch ($action) {
             }
         }
 
-        $orderId = addOrder($pdo, $userId, date('Y-m-d'), 'Pending');
+        $orderId = addOrder($pdo, $userId, date('Y-m-d'), 'Pending', 'online', $orderType);
         $total = 0;
         foreach ($items as $it) {
             $stmt = $pdo->prepare('SELECT Price FROM product WHERE Product_ID = :id');

--- a/PHP/order_functions.php
+++ b/PHP/order_functions.php
@@ -1,13 +1,25 @@
 <?php
 // 1) Create a new order
-function addOrder($pdo, $userId, $orderDate, $status) {
+function addOrder($pdo, $userId, $orderDate, $status, $source = 'online', $fulfillmentType = 'Delivery') {
+    $validSources = ['online', 'walk-in'];
+    if (in_array($source, $validSources, true) === false) {
+        $source = 'online';
+    }
+
+    $validFulfillment = ['Delivery', 'Pick up'];
+    if (in_array($fulfillmentType, $validFulfillment, true) === false) {
+        $fulfillmentType = 'Delivery';
+    }
+
     $stmt = $pdo->prepare("
-        INSERT INTO `order` (User_ID, Order_Date, Status)
-        VALUES (:user_id, :order_date, :status)
+        INSERT INTO `order` (User_ID, Order_Date, Source, Fulfillment_Type, Status)
+        VALUES (:user_id, :order_date, :source, :fulfillment_type, :status)
     ");
     $stmt->execute([
         ':user_id' => $userId,
         ':order_date' => $orderDate,
+        ':source' => $source,
+        ':fulfillment_type' => $fulfillmentType,
         ':status' => $status
     ]);
     return $pdo->lastInsertId();
@@ -25,13 +37,15 @@ function getOrdersByUserId($pdo, $userId) {
         SELECT o.Order_ID,
                o.User_ID,
                o.Order_Date,
+               o.Source,
+               o.Fulfillment_Type,
                o.Status,
                MIN(p.Image_Path) AS Image_Path
         FROM `order` o
         LEFT JOIN order_item oi ON o.Order_ID = oi.Order_ID
         LEFT JOIN product p ON oi.Product_ID = p.Product_ID
         WHERE o.User_ID = :user_id
-        GROUP BY o.Order_ID, o.User_ID, o.Order_Date, o.Status
+        GROUP BY o.Order_ID, o.User_ID, o.Order_Date, o.Source, o.Fulfillment_Type, o.Status
     ");
     $stmt->execute([':user_id' => $userId]);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The SQL dump defines the following tables:
 - **cart_item** – items placed in a shopping cart (`Cart_Item_ID`, `Cart_ID`, `Product_ID`, `Quantity`)
 - **delivery** – delivery status for orders (`Delivery_ID`, `Order_ID`, `Status`, `Delivery_Date`, `Delivery_Personnel` [User_ID])
 - **inventory** – stock levels for products (`Inventory_ID`, `Product_ID`, `Stock_Quantity`)
-- **order** – customer orders (`Order_ID`, `User_ID`, `Order_Date`, `Status`)
+- **order** – customer orders (`Order_ID`, `User_ID`, `Order_Date`, `Source`, `Fulfillment_Type`, `Status`)
 - **order_item** – products within an order (`Order_Item_ID`, `Order_ID`, `Product_ID`, `Quantity`, `Subtotal`)
 - **product** – product catalog (`Product_ID`, `Name`, `Description`, `Price`, `Stock_Quantity`, `Category`, `Image_Path`)
 - **shopping_cart** – cart ownership (`Cart_ID`, `User_ID`)
@@ -56,6 +56,15 @@ The SQL dump defines the following tables:
    - `DB_PASSWORD` – database password (defaults to an empty string)
    - `DB_CHARSET` – character set (defaults to `utf8mb4`)
 
+### Upgrading an Existing Database
+If you are updating an existing installation, apply the `Database/add_order_source_columns.sql` migration after pulling the latest code. The script adds the new `Source` and `Fulfillment_Type` columns required by the admin tooling.
+
+```sh
+mysql -u root -p cindysdb < Database/add_order_source_columns.sql
+```
+
+Run the command with your own database name and credentials.
+
 ### Running MySQL as a Service (Windows/XAMPP)
 To avoid manually launching the XAMPP control panel each time:
 
@@ -74,6 +83,17 @@ php -S localhost:8000
 ```
 - Browse the customer-facing site at `http://localhost:8000/userSide`.
 - Access the admin dashboard at `http://localhost:8000/adminSide`.
+
+## Walk-in Orders (Admin)
+The admin dashboard now includes a **New Order** builder under **Orders ▸ New Order** for recording walk-in sales. The tool works alongside the online checkout flow by storing the order `Source` and `Fulfillment_Type` in the database.
+
+1. Open the admin site and navigate to **Orders ▸ New Order** from the sidebar.
+2. Select an existing customer or create a quick profile for a new walk-in guest.
+3. Choose the fulfillment method (Delivery or Pick up), payment method/status, and optional reference number.
+4. Search for products, add them to the summary grid, and adjust quantities as needed.
+5. Submit the form to generate the order. Stock levels, transactions, and (for deliveries) a pending delivery record are created automatically.
+
+If an email address is provided, the customer receives the standard confirmation email. The order appears on the **Manage Orders** page with its source and fulfillment details so staff can quickly distinguish in-store tickets.
 
 ## Firebase Configuration
 Firebase settings are served from a dedicated endpoint rather than being

--- a/adminSide/api/walkin_order_actions.php
+++ b/adminSide/api/walkin_order_actions.php
@@ -1,0 +1,279 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Invalid request method']);
+    exit;
+}
+
+require_once '../../PHP/db_connect.php';
+require_once '../../PHP/order_functions.php';
+require_once '../../PHP/order_item_functions.php';
+require_once '../../PHP/product_functions.php';
+require_once '../../PHP/inventory_functions.php';
+require_once '../../PHP/transaction_functions.php';
+require_once '../../PHP/user_functions.php';
+require_once '../../PHP/delivery_functions.php';
+require_once '../../PHP/email_functions.php';
+
+if (!$pdo) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database connection failed']);
+    exit;
+}
+
+$action = filter_input(INPUT_POST, 'action', FILTER_SANITIZE_SPECIAL_CHARS) ?: '';
+$token = filter_input(INPUT_POST, 'csrf_token', FILTER_SANITIZE_SPECIAL_CHARS) ?: '';
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    exit;
+}
+
+$respond = static function (int $status, array $payload): void {
+    http_response_code($status);
+    echo json_encode($payload);
+    exit;
+};
+
+switch ($action) {
+    case 'search_products':
+        $query = trim(filter_input(INPUT_POST, 'query', FILTER_SANITIZE_SPECIAL_CHARS) ?? '');
+        $limit = filter_input(INPUT_POST, 'limit', FILTER_VALIDATE_INT);
+        if (!is_int($limit) || $limit <= 0 || $limit > 100) {
+            $limit = 20;
+        }
+        $inStockOnly = filter_input(INPUT_POST, 'in_stock_only', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        $sql = "SELECT p.Product_ID, p.Name, p.Price, p.Category,\n                       COALESCE(i.Stock_Quantity, p.Stock_Quantity) AS Stock_Quantity\n                FROM product p\n                LEFT JOIN inventory i ON i.Product_ID = p.Product_ID";
+        $conditions = [];
+        $params = [];
+        if ($query !== '') {
+            $conditions[] = '(p.Name LIKE :term OR p.Category LIKE :term)';
+            $params[':term'] = "%$query%";
+        }
+        if ($inStockOnly === true) {
+            $conditions[] = 'COALESCE(i.Stock_Quantity, p.Stock_Quantity) > 0';
+        }
+        if ($conditions) {
+            $sql .= ' WHERE ' . implode(' AND ', $conditions);
+        }
+        $sql .= ' ORDER BY p.Name ASC LIMIT :limit';
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_STR);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        $products = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $products[] = [
+                'id' => (int)$row['Product_ID'],
+                'name' => $row['Name'],
+                'price' => (float)$row['Price'],
+                'category' => $row['Category'],
+                'stock' => (int)($row['Stock_Quantity'] ?? 0)
+            ];
+        }
+        $respond(200, ['success' => true, 'products' => $products]);
+        break;
+
+    case 'search_customers':
+        $query = trim(filter_input(INPUT_POST, 'query', FILTER_SANITIZE_SPECIAL_CHARS) ?? '');
+        $limit = filter_input(INPUT_POST, 'limit', FILTER_VALIDATE_INT);
+        if (!is_int($limit) || $limit <= 0 || $limit > 50) {
+            $limit = 10;
+        }
+        $sql = "SELECT User_ID, Name, Email, Address FROM user";
+        $params = [];
+        if ($query !== '') {
+            $sql .= ' WHERE Name LIKE :term OR Email LIKE :term';
+            $params[':term'] = "%$query%";
+        }
+        $sql .= ' ORDER BY Name ASC LIMIT :limit';
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_STR);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $customers = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $customers[] = [
+                'id' => (int)$row['User_ID'],
+                'name' => $row['Name'],
+                'email' => $row['Email'] ?? '',
+                'address' => $row['Address'] ?? ''
+            ];
+        }
+        $respond(200, ['success' => true, 'customers' => $customers]);
+        break;
+
+    case 'create_order':
+        $customerMode = filter_input(INPUT_POST, 'customer_mode', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'existing';
+        $customerMode = in_array($customerMode, ['existing', 'new'], true) ? $customerMode : 'existing';
+
+        $itemsRaw = $_POST['items'] ?? '[]';
+        $itemsData = json_decode($itemsRaw, true);
+        if (!is_array($itemsData) || empty($itemsData)) {
+            $respond(422, ['success' => false, 'message' => 'Please add at least one product.']);
+        }
+
+        $orderItems = [];
+        $orderTotal = 0.0;
+
+        foreach ($itemsData as $item) {
+            $productId = isset($item['product_id']) ? (int)$item['product_id'] : 0;
+            $quantity = isset($item['quantity']) ? (int)$item['quantity'] : 0;
+            if ($productId <= 0 || $quantity <= 0) {
+                $respond(422, ['success' => false, 'message' => 'Invalid product selection provided.']);
+            }
+
+            $product = getProductById($pdo, $productId);
+            if (!$product) {
+                $respond(404, ['success' => false, 'message' => "Product ID {$productId} does not exist."]);
+            }
+
+            $inventory = getInventoryByProductId($pdo, $productId);
+            $availableStock = (int)($inventory['Stock_Quantity'] ?? $product['Stock_Quantity'] ?? 0);
+            if ($quantity > $availableStock) {
+                $respond(422, ['success' => false, 'message' => "Not enough stock for {$product['Name']}."]);
+            }
+
+            $price = (float)$product['Price'];
+            $subtotal = $price * $quantity;
+            $orderTotal += $subtotal;
+            $orderItems[] = [
+                'product_id' => $productId,
+                'quantity' => $quantity,
+                'price' => $price,
+                'subtotal' => $subtotal
+            ];
+        }
+
+        $fulfillmentType = filter_input(INPUT_POST, 'fulfillment_type', FILTER_SANITIZE_SPECIAL_CHARS) ?: '';
+        $allowedFulfillment = ['Delivery', 'Pick up'];
+        if (!in_array($fulfillmentType, $allowedFulfillment, true)) {
+            $fulfillmentType = 'Pick up';
+        }
+
+        $orderStatus = filter_input(INPUT_POST, 'order_status', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'Pending';
+        $allowedStatuses = ['Pending', 'Confirmed', 'Shipped', 'Delivered'];
+        if (!in_array($orderStatus, $allowedStatuses, true)) {
+            $orderStatus = 'Pending';
+        }
+
+        $paymentMethod = trim(filter_input(INPUT_POST, 'payment_method', FILTER_SANITIZE_SPECIAL_CHARS) ?? 'Cash');
+        if ($paymentMethod === '') {
+            $paymentMethod = 'Cash';
+        }
+
+        $paymentStatusInput = filter_input(INPUT_POST, 'payment_status', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'Paid';
+        $allowedPaymentStatuses = ['Paid', 'Pending', 'Partially Paid'];
+        $paymentStatus = in_array($paymentStatusInput, $allowedPaymentStatuses, true) ? $paymentStatusInput : 'Paid';
+
+        $paymentAmount = filter_input(INPUT_POST, 'payment_amount', FILTER_VALIDATE_FLOAT);
+        if (!is_float($paymentAmount) || $paymentAmount < 0) {
+            $paymentAmount = $paymentStatus === 'Paid' ? $orderTotal : 0.0;
+        }
+        $paymentAmount = min($paymentAmount, $orderTotal);
+
+        $referenceNumber = trim(filter_input(INPUT_POST, 'reference_number', FILTER_SANITIZE_SPECIAL_CHARS) ?? '');
+        if ($referenceNumber === '') {
+            $referenceNumber = null;
+        }
+
+        $customerEmail = '';
+        $customerAddress = '';
+
+        try {
+            $pdo->beginTransaction();
+
+            if ($customerMode === 'existing') {
+                $userId = filter_input(INPUT_POST, 'user_id', FILTER_VALIDATE_INT);
+                if (!$userId) {
+                    throw new InvalidArgumentException('Select an existing customer to continue.', 422);
+                }
+                $user = getUserById($pdo, $userId);
+                if (!$user) {
+                    throw new InvalidArgumentException('Selected customer could not be found.', 404);
+                }
+                $customerEmail = $user['Email'] ?? '';
+                $customerAddress = $user['Address'] ?? '';
+            } else {
+                $name = trim($_POST['customer_name'] ?? '');
+                if ($name === '') {
+                    throw new InvalidArgumentException('Customer name is required for new accounts.', 422);
+                }
+                $emailInput = trim($_POST['customer_email'] ?? '');
+                if ($emailInput !== '') {
+                    if (!filter_var($emailInput, FILTER_VALIDATE_EMAIL)) {
+                        throw new InvalidArgumentException('Please provide a valid email address.', 422);
+                    }
+                    if (checkEmailExists($pdo, $emailInput)) {
+                        throw new InvalidArgumentException('Email address is already associated with an account.', 422);
+                    }
+                    $customerEmail = $emailInput;
+                }
+                $customerAddress = trim($_POST['customer_address'] ?? '');
+                $randomPassword = bin2hex(random_bytes(8));
+                $userId = addUser($pdo, $name, $customerEmail ?: null, $randomPassword, $customerAddress ?: null);
+            }
+
+            $orderId = addOrder($pdo, $userId, date('Y-m-d'), $orderStatus, 'walk-in', $fulfillmentType);
+
+            foreach ($orderItems as $line) {
+                addOrderItem($pdo, $orderId, $line['product_id'], $line['quantity'], $line['subtotal']);
+                adjustInventoryStock($pdo, $line['product_id'], -$line['quantity']);
+                adjustProductStock($pdo, $line['product_id'], -$line['quantity']);
+            }
+
+            $paymentDate = date('Y-m-d');
+            addTransaction($pdo, $orderId, $paymentMethod, $paymentStatus, $paymentDate, $paymentAmount, $referenceNumber);
+
+            if ($fulfillmentType === 'Delivery') {
+                addDelivery($pdo, $orderId, 'Pending', null, null);
+            }
+
+            $pdo->commit();
+        } catch (InvalidArgumentException $exception) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            $code = $exception->getCode();
+            if ($code < 400 || $code > 599) {
+                $code = 422;
+            }
+            $respond($code, ['success' => false, 'message' => $exception->getMessage()]);
+        } catch (Throwable $exception) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            error_log('Walk-in order API error: ' . $exception->getMessage());
+            $respond(500, ['success' => false, 'message' => 'Unable to create the order. Please try again.']);
+        }
+
+        if ($customerEmail !== '') {
+            try {
+                sendOrderConfirmationEmail($customerEmail, $orderId, $orderTotal);
+            } catch (Throwable $exception) {
+                error_log('Walk-in order email error: ' . $exception->getMessage());
+            }
+        }
+
+        $respond(200, [
+            'success' => true,
+            'order_id' => (int)$orderId,
+            'total' => $orderTotal
+        ]);
+        break;
+
+    default:
+        $respond(400, ['success' => false, 'message' => 'Unknown action']);
+}

--- a/adminSide/assets/css/admin.css
+++ b/adminSide/assets/css/admin.css
@@ -659,3 +659,363 @@ button,
     padding: 24px;
   }
 }
+
+.walkin-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.builder-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.builder-card {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+}
+
+.builder-card h2 {
+  font-size: 20px;
+  margin-bottom: 4px;
+  color: #111;
+}
+
+.card-header p {
+  font-size: 14px;
+  color: var(--muted-text);
+}
+
+.customer-mode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.customer-mode label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #333;
+}
+
+.customer-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.customer-summary {
+  background: #f4f6f8;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.customer-summary.empty {
+  color: var(--muted-text);
+  font-style: italic;
+}
+
+.customer-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.customer-details span {
+  font-size: 13px;
+  color: var(--muted-text);
+}
+
+.search-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid #ecf0f1;
+  border-radius: 12px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.search-result {
+  padding: 10px 14px;
+  border-bottom: 1px solid #ecf0f1;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.search-result:last-child {
+  border-bottom: none;
+}
+
+.search-result strong {
+  color: #111;
+}
+
+.search-result span {
+  font-size: 13px;
+  color: var(--muted-text);
+}
+
+.search-result:hover {
+  background: rgba(231, 76, 60, 0.08);
+}
+
+.product-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.inline-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+}
+
+.product-layout {
+  display: grid;
+  gap: 20px;
+}
+
+@media (min-width: 992px) {
+  .product-layout {
+    grid-template-columns: minmax(0, 1.15fr) minmax(320px, 1fr);
+  }
+}
+
+.product-list {
+  display: grid;
+  gap: 12px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.product-card {
+  border: 1px solid #ecf0f1;
+  border-radius: 14px;
+  padding: 16px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.05);
+}
+
+.product-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #111;
+  font-size: 15px;
+}
+
+.product-title span {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-text);
+}
+
+.product-meta {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.product-meta .stock {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.product-meta .stock.low {
+  color: #d68910;
+}
+
+.product-meta .stock.out {
+  color: var(--primary);
+}
+
+.product-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.order-summary {
+  background: #f9fbfc;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  box-shadow: inset 0 0 0 1px #ecf0f1;
+}
+
+.order-summary-header {
+  padding: 18px 20px 0;
+}
+
+.order-summary-body {
+  padding: 0 20px;
+  overflow-x: auto;
+}
+
+.order-summary-footer {
+  padding: 16px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 10px 8px;
+  text-align: left;
+  font-size: 14px;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.summary-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.summary-empty td {
+  text-align: center;
+  color: var(--muted-text);
+  font-style: italic;
+}
+
+.summary-name {
+  font-weight: 600;
+}
+
+.quantity-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #f1f2f6;
+  border-radius: 10px;
+  padding: 4px;
+}
+
+.quantity-control input {
+  width: 54px;
+  border: none;
+  background: transparent;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.qty-btn {
+  background: #fff;
+  border: 1px solid #dcdfe3;
+  border-radius: 8px;
+  width: 28px;
+  height: 28px;
+  font-size: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.qty-btn:hover {
+  background: rgba(231, 76, 60, 0.12);
+}
+
+.total-row {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.form-messages {
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.5;
+  transition: opacity 0.2s ease;
+}
+
+.form-messages.is-hidden {
+  display: none;
+}
+
+.form-messages.is-success {
+  background: rgba(46, 204, 113, 0.15);
+  border: 1px solid rgba(46, 204, 113, 0.45);
+  color: #1e8449;
+}
+
+.form-messages.is-error {
+  background: rgba(231, 76, 60, 0.15);
+  border: 1px solid rgba(231, 76, 60, 0.45);
+  color: #c0392b;
+}
+
+.helper-text {
+  font-size: 13px;
+  color: var(--muted-text);
+}
+
+.btn-small {
+  padding: 6px 12px;
+  font-size: 12px;
+  border-radius: 6px;
+}
+
+.empty-state {
+  padding: 18px;
+  text-align: center;
+  border: 1px dashed #d5d8dc;
+  border-radius: 12px;
+  font-size: 14px;
+  color: var(--muted-text);
+  background: #fdfefe;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+.link-order {
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.link-order:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .builder-card {
+    padding: 20px;
+  }
+
+  .product-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/adminSide/includes/sidebar.php
+++ b/adminSide/includes/sidebar.php
@@ -30,13 +30,19 @@ function isDropdownActive(array $pages, $activePage) {
         Products
       </a>
     </li>
-    <li class="dropdown <?= isDropdownActive(['orders', 'delivery'], $activePage); ?>">
+    <li class="dropdown <?= isDropdownActive(['orders', 'delivery', 'walkin-order'], $activePage); ?>">
       <a href="#">
         <span><i class="fa-solid fa-cart-shopping"></i></span>
         Orders
         <i class="fa-solid fa-caret-down" style="margin-left:auto;"></i>
       </a>
       <ul class="submenu">
+        <li>
+          <a href="walkin-order.php" class="<?= isActive('walkin-order', $activePage); ?>">
+            <i class="fa-solid fa-cart-plus"></i>
+            New Order
+          </a>
+        </li>
         <li>
           <a href="orders.php" class="<?= isActive('orders', $activePage); ?>">
             <i class="fa-solid fa-list-check"></i>

--- a/adminSide/orders.php
+++ b/adminSide/orders.php
@@ -13,7 +13,7 @@ $pageTitle = "Manage Orders - Cindy's Bakeshop";
 $orders = [];
 $statusOptions = ['Pending', 'Confirmed', 'Shipped', 'Delivered'];
 if ($pdo) {
-    $sql = "SELECT o.Order_ID, o.Order_Date, o.Status, u.Name, 
+    $sql = "SELECT o.Order_ID, o.Order_Date, o.Status, o.Source, o.Fulfillment_Type, u.Name, 
                    COALESCE(SUM(oi.Quantity), 0) AS Item_Count,
                    COALESCE(SUM(oi.Subtotal), 0) AS Total_Amount,
                    GROUP_CONCAT(CONCAT(p.Name, ' x', oi.Quantity) SEPARATOR ', ') AS Item_Summary
@@ -21,7 +21,7 @@ if ($pdo) {
             LEFT JOIN user u ON o.User_ID = u.User_ID
             LEFT JOIN order_item oi ON oi.Order_ID = o.Order_ID
             LEFT JOIN product p ON oi.Product_ID = p.Product_ID
-            GROUP BY o.Order_ID, o.Order_Date, o.Status, u.Name
+            GROUP BY o.Order_ID, o.Order_Date, o.Status, o.Source, o.Fulfillment_Type, u.Name
             ORDER BY o.Order_Date DESC, o.Order_ID DESC";
     $stmt = $pdo->query($sql);
     $orders = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
@@ -56,6 +56,8 @@ include 'includes/sidebar.php';
           <th>#</th>
           <th>Customer</th>
           <th>Items</th>
+          <th>Source</th>
+          <th>Fulfillment</th>
           <th>Total</th>
           <th>Status</th>
           <th>Date</th>
@@ -65,14 +67,26 @@ include 'includes/sidebar.php';
       <tbody>
         <?php if (empty($orders)): ?>
           <tr>
-            <td colspan="7" class="table-empty">No orders found.</td>
+            <td colspan="9" class="table-empty">No orders found.</td>
           </tr>
         <?php else: ?>
           <?php foreach ($orders as $order): ?>
-            <tr data-order-id="<?= $order['Order_ID']; ?>" data-status="<?= htmlspecialchars($order['Status']); ?>">
+            <?php
+              $sourceValue = $order['Source'] ?? '';
+              $sourceLabel = $sourceValue ? ucwords(str_replace(['-', '_'], [' ', ' '], $sourceValue)) : '—';
+              $fulfillmentLabel = $order['Fulfillment_Type'] ?? '—';
+              $itemSummary = $order['Item_Summary'] ?? 'No items recorded';
+            ?>
+            <tr data-order-id="<?= $order['Order_ID']; ?>"
+                data-status="<?= htmlspecialchars($order['Status']); ?>"
+                data-source="<?= htmlspecialchars($sourceValue); ?>"
+                data-fulfillment="<?= htmlspecialchars($order['Fulfillment_Type'] ?? ''); ?>"
+                data-summary="<?= htmlspecialchars($itemSummary); ?>">
               <td>#<?= str_pad($order['Order_ID'], 5, '0', STR_PAD_LEFT); ?></td>
               <td><?= htmlspecialchars($order['Name'] ?? 'Customer ' . $order['Order_ID']); ?></td>
-              <td><?= htmlspecialchars($order['Item_Summary'] ?? 'No items recorded'); ?></td>
+              <td><?= htmlspecialchars($itemSummary); ?></td>
+              <td><?= htmlspecialchars($sourceLabel); ?></td>
+              <td><?= htmlspecialchars($fulfillmentLabel); ?></td>
               <td>₱<?= number_format($order['Total_Amount'] ?? 0, 2); ?></td>
               <td>
                 <span class="status-pill status-<?= strtolower($order['Status']); ?>">
@@ -121,6 +135,8 @@ $ordersJson = json_encode(array_map(static function ($order) {
         'status' => $order['Status'],
         'summary' => $order['Item_Summary'] ?? '',
         'date' => $order['Order_Date'] ?? '',
+        'source' => $order['Source'] ?? '',
+        'fulfillment' => $order['Fulfillment_Type'] ?? '',
     ];
 }, $orders));
 $csrfToken = json_encode($_SESSION['csrf_token']);
@@ -215,9 +231,11 @@ $extraScripts = <<<JS
       if (!cells.length) return;
       const id = cells[0].textContent.toLowerCase();
       const customer = cells[1].textContent.toLowerCase();
-      const summary = cells[2].textContent.toLowerCase();
+      const summary = (row.dataset.summary || '').toLowerCase();
+      const source = (row.dataset.source || '').toLowerCase();
+      const fulfillment = (row.dataset.fulfillment || '').toLowerCase();
       const rowStatus = row.dataset.status;
-      const matchesSearch = id.includes(query) || customer.includes(query) || summary.includes(query);
+      const matchesSearch = id.includes(query) || customer.includes(query) || summary.includes(query) || source.includes(query) || fulfillment.includes(query);
       const matchesStatus = status === 'all' || rowStatus === status;
       row.style.display = matchesSearch && matchesStatus ? '' : 'none';
     });

--- a/adminSide/walkin-order.php
+++ b/adminSide/walkin-order.php
@@ -1,0 +1,680 @@
+<?php
+session_start();
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$activePage = 'walkin-order';
+$pageTitle = "New Walk-in Order - Cindy's Bakeshop";
+
+include 'includes/header.php';
+include 'includes/sidebar.php';
+?>
+
+<div class="main">
+  <div class="page-header">
+    <h1>Create Walk-in Order</h1>
+    <a href="edit-profile.php" class="user-info">
+      <span>Admin</span>
+      <img src="https://i.pravatar.cc/80" alt="Admin avatar">
+    </a>
+  </div>
+
+  <div class="walkin-builder">
+    <form id="walkinOrderForm" autocomplete="off">
+      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token']); ?>">
+      <div class="builder-grid">
+        <section class="builder-card">
+          <div class="card-header">
+            <h2>Customer</h2>
+            <p>Search an existing customer or capture details for a new guest.</p>
+          </div>
+          <div class="customer-mode">
+            <label>
+              <input type="radio" name="customer_mode" value="existing" checked>
+              Existing customer
+            </label>
+            <label>
+              <input type="radio" name="customer_mode" value="new">
+              New customer
+            </label>
+          </div>
+          <div class="customer-section" id="existingCustomerSection">
+            <label for="customerSearch">Search</label>
+            <input type="search" id="customerSearch" placeholder="Search by name or email">
+            <p class="helper-text">Start typing to load matching accounts.</p>
+            <ul class="search-results" id="customerResults" aria-live="polite"></ul>
+            <div class="customer-summary empty" id="customerSummary">
+              <p>No customer selected.</p>
+            </div>
+          </div>
+          <div class="customer-section is-hidden" id="newCustomerSection">
+            <label for="newCustomerName">Name</label>
+            <input type="text" id="newCustomerName" placeholder="Customer name">
+            <label for="newCustomerEmail">Email <span class="helper-text">(optional)</span></label>
+            <input type="email" id="newCustomerEmail" placeholder="customer@example.com">
+            <label for="newCustomerAddress">Address <span class="helper-text">(optional)</span></label>
+            <textarea id="newCustomerAddress" rows="3" placeholder="Street, barangay, city"></textarea>
+          </div>
+        </section>
+
+        <section class="builder-card">
+          <div class="card-header">
+            <h2>Fulfillment &amp; Payment</h2>
+            <p>Record how the order will be fulfilled and paid.</p>
+          </div>
+          <div class="form-field">
+            <label for="fulfillmentType">Fulfillment type</label>
+            <select id="fulfillmentType">
+              <option value="Pick up">Pick up</option>
+              <option value="Delivery">Delivery</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="orderStatus">Order status</label>
+            <select id="orderStatus">
+              <?php foreach (['Pending', 'Confirmed', 'Shipped', 'Delivered'] as $status): ?>
+                <option value="<?= htmlspecialchars($status); ?>"><?= htmlspecialchars($status); ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="paymentMethod">Payment method</label>
+            <select id="paymentMethod">
+              <option value="Cash">Cash</option>
+              <option value="GCash">GCash</option>
+              <option value="Card">Card</option>
+              <option value="Bank transfer">Bank transfer</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="paymentStatus">Payment status</label>
+            <select id="paymentStatus">
+              <option value="Paid" selected>Paid</option>
+              <option value="Pending">Pending</option>
+              <option value="Partially Paid">Partially Paid</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="paymentAmount">Amount collected</label>
+            <input type="number" id="paymentAmount" min="0" step="0.01" value="0.00">
+          </div>
+          <div class="form-field">
+            <label for="referenceNumber">Reference # <span class="helper-text">(optional)</span></label>
+            <input type="text" id="referenceNumber" maxlength="100" placeholder="Receipt or transaction reference">
+          </div>
+        </section>
+
+        <section class="builder-card builder-wide">
+          <div class="card-header">
+            <h2>Products &amp; Summary</h2>
+            <p>Search the catalogue, add items to the order, and confirm quantities.</p>
+          </div>
+          <div class="product-toolbar">
+            <div class="form-field">
+              <label for="productSearch">Product search</label>
+              <input type="search" id="productSearch" placeholder="Search by name or category">
+            </div>
+            <label class="inline-checkbox">
+              <input type="checkbox" id="inStockOnly" checked>
+              In stock only
+            </label>
+          </div>
+          <div class="product-layout">
+            <div class="product-list" id="productResults" aria-live="polite"></div>
+            <div class="order-summary">
+              <div class="order-summary-header">
+                <h3>Order summary</h3>
+                <p class="helper-text">Adjust quantities before creating the order.</p>
+              </div>
+              <div class="order-summary-body">
+                <table class="summary-table">
+                  <thead>
+                    <tr>
+                      <th>Item</th>
+                      <th style="width:120px;">Qty</th>
+                      <th>Price</th>
+                      <th>Subtotal</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody id="orderSummaryBody">
+                    <tr class="summary-empty">
+                      <td colspan="5">No items selected yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="order-summary-footer">
+                <div class="total-row">
+                  <span>Total</span>
+                  <span id="orderTotal">₱0.00</span>
+                </div>
+                <div id="formErrors" class="form-messages is-hidden" role="alert"></div>
+                <button type="submit" class="btn btn-primary btn-submit">Create walk-in order</button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </form>
+    <div id="walkinMessages" class="form-messages is-hidden" role="alert"></div>
+  </div>
+</div>
+
+<?php
+$csrfTokenJson = json_encode($_SESSION['csrf_token']);
+$apiUrlJson = json_encode('api/walkin_order_actions.php');
+$ordersUrlJson = json_encode('orders.php');
+$scriptTemplate = <<<'JS'
+<script>
+(() => {
+  const csrfToken = %s;
+  const apiUrl = %s;
+  const ordersUrl = %s;
+  const form = document.getElementById('walkinOrderForm');
+  const customerModeRadios = form.querySelectorAll('input[name="customer_mode"]');
+  const existingSection = document.getElementById('existingCustomerSection');
+  const newSection = document.getElementById('newCustomerSection');
+  const customerSearchInput = document.getElementById('customerSearch');
+  const customerResults = document.getElementById('customerResults');
+  const customerSummary = document.getElementById('customerSummary');
+  const newCustomerName = document.getElementById('newCustomerName');
+  const newCustomerEmail = document.getElementById('newCustomerEmail');
+  const newCustomerAddress = document.getElementById('newCustomerAddress');
+  const fulfillmentTypeSelect = document.getElementById('fulfillmentType');
+  const orderStatusSelect = document.getElementById('orderStatus');
+  const paymentMethodSelect = document.getElementById('paymentMethod');
+  const paymentStatusSelect = document.getElementById('paymentStatus');
+  const paymentAmountInput = document.getElementById('paymentAmount');
+  const referenceNumberInput = document.getElementById('referenceNumber');
+  const productSearchInput = document.getElementById('productSearch');
+  const inStockOnlyCheckbox = document.getElementById('inStockOnly');
+  const productResultsContainer = document.getElementById('productResults');
+  const summaryBody = document.getElementById('orderSummaryBody');
+  const orderTotalLabel = document.getElementById('orderTotal');
+  const formErrors = document.getElementById('formErrors');
+  const messages = document.getElementById('walkinMessages');
+
+  const peso = new Intl.NumberFormat('en-PH', { style: 'currency', currency: 'PHP' });
+
+  const selectedItems = new Map();
+  let selectedCustomer = null;
+  let customerSearchTimer = null;
+  let productSearchTimer = null;
+  let paymentAmountTouched = false;
+
+  function setMessage(target, type, text) {
+    if (!target) return;
+    target.textContent = text;
+    target.classList.remove('is-hidden', 'is-success', 'is-error');
+    if (type === 'success') {
+      target.classList.add('is-success');
+    } else if (type === 'error') {
+      target.classList.add('is-error');
+    }
+  }
+
+  function clearMessage(target) {
+    if (!target) return;
+    target.textContent = '';
+    target.classList.add('is-hidden');
+    target.classList.remove('is-success', 'is-error');
+  }
+
+  function renderCustomerSummary() {
+    if (!customerSummary) return;
+    customerSummary.innerHTML = '';
+    customerSummary.classList.remove('empty');
+    if (!selectedCustomer) {
+      customerSummary.classList.add('empty');
+      customerSummary.innerHTML = '<p>No customer selected.</p>';
+      return;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'customer-details';
+
+    const name = document.createElement('strong');
+    name.textContent = selectedCustomer.name;
+    wrapper.appendChild(name);
+
+    if (selectedCustomer.email) {
+      const email = document.createElement('span');
+      email.textContent = selectedCustomer.email;
+      wrapper.appendChild(email);
+    }
+
+    if (selectedCustomer.address) {
+      const address = document.createElement('span');
+      address.textContent = selectedCustomer.address;
+      wrapper.appendChild(address);
+    }
+
+    const clearBtn = document.createElement('button');
+    clearBtn.type = 'button';
+    clearBtn.className = 'btn btn-muted btn-small';
+    clearBtn.textContent = 'Clear selection';
+    clearBtn.addEventListener('click', () => {
+      selectedCustomer = null;
+      renderCustomerSummary();
+    });
+
+    customerSummary.appendChild(wrapper);
+    customerSummary.appendChild(clearBtn);
+  }
+
+  function createProductCard(product) {
+    const card = document.createElement('div');
+    card.className = 'product-card';
+    card.dataset.id = String(product.id);
+
+    const title = document.createElement('div');
+    title.className = 'product-title';
+    title.innerHTML = `<strong>${product.name}</strong><span>${product.category || 'Uncategorised'}</span>`;
+    card.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'product-meta';
+    const stockClass = product.stock <= 0 ? 'out' : product.stock < 10 ? 'low' : '';
+    const stockText = product.stock > 0 ? `Stock: ${product.stock}` : 'Out of stock';
+    meta.innerHTML = `<span>${peso.format(product.price)}</span><span class="stock ${stockClass}">${stockText}</span>`;
+    card.appendChild(meta);
+
+    const actions = document.createElement('div');
+    actions.className = 'product-actions';
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'btn btn-secondary';
+    addButton.textContent = 'Add';
+    addButton.disabled = product.stock <= 0;
+    addButton.addEventListener('click', () => {
+      const existing = selectedItems.get(product.id) || { ...product, quantity: 0 };
+      if (existing.quantity >= product.stock) {
+        setMessage(formErrors, 'error', `Only ${product.stock} piece(s) of ${product.name} available.`);
+        return;
+      }
+      existing.quantity += 1;
+      existing.stock = product.stock;
+      selectedItems.set(product.id, existing);
+      renderSelectedItems();
+      clearMessage(formErrors);
+    });
+
+    actions.appendChild(addButton);
+    card.appendChild(actions);
+    return card;
+  }
+
+  function renderProductResults(products) {
+    productResultsContainer.innerHTML = '';
+    if (!products.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No products matched the search.';
+      productResultsContainer.appendChild(empty);
+      return;
+    }
+    products.forEach((product) => {
+      productResultsContainer.appendChild(createProductCard(product));
+    });
+  }
+
+  function updateQuantity(id, nextQuantity) {
+    const item = selectedItems.get(id);
+    if (!item) return;
+    if (nextQuantity < 1) {
+      nextQuantity = 1;
+    }
+    if (nextQuantity > item.stock) {
+      nextQuantity = item.stock;
+      setMessage(formErrors, 'error', `Only ${item.stock} piece(s) of ${item.name} available.`);
+    } else {
+      clearMessage(formErrors);
+    }
+    item.quantity = nextQuantity;
+    selectedItems.set(id, item);
+    renderSelectedItems();
+  }
+
+  function renderSelectedItems() {
+    summaryBody.innerHTML = '';
+    let total = 0;
+    if (!selectedItems.size) {
+      const row = document.createElement('tr');
+      row.className = 'summary-empty';
+      const cell = document.createElement('td');
+      cell.colSpan = 5;
+      cell.textContent = 'No items selected yet.';
+      row.appendChild(cell);
+      summaryBody.appendChild(row);
+    } else {
+      selectedItems.forEach((item, id) => {
+        const row = document.createElement('tr');
+        row.dataset.id = String(id);
+
+        const nameCell = document.createElement('td');
+        nameCell.className = 'summary-name';
+        nameCell.textContent = item.name;
+        row.appendChild(nameCell);
+
+        const qtyCell = document.createElement('td');
+        const qtyWrapper = document.createElement('div');
+        qtyWrapper.className = 'quantity-control';
+
+        const minusBtn = document.createElement('button');
+        minusBtn.type = 'button';
+        minusBtn.className = 'qty-btn';
+        minusBtn.textContent = '−';
+        minusBtn.addEventListener('click', () => updateQuantity(id, item.quantity - 1));
+        qtyWrapper.appendChild(minusBtn);
+
+        const qtyInput = document.createElement('input');
+        qtyInput.type = 'number';
+        qtyInput.min = '1';
+        qtyInput.max = String(item.stock);
+        qtyInput.value = String(item.quantity);
+        qtyInput.addEventListener('change', () => {
+          const next = Math.max(1, Math.min(item.stock, parseInt(qtyInput.value, 10) || 1));
+          updateQuantity(id, next);
+        });
+        qtyWrapper.appendChild(qtyInput);
+
+        const plusBtn = document.createElement('button');
+        plusBtn.type = 'button';
+        plusBtn.className = 'qty-btn';
+        plusBtn.textContent = '+';
+        plusBtn.addEventListener('click', () => updateQuantity(id, item.quantity + 1));
+        qtyWrapper.appendChild(plusBtn);
+
+        qtyCell.appendChild(qtyWrapper);
+        row.appendChild(qtyCell);
+
+        const priceCell = document.createElement('td');
+        priceCell.textContent = peso.format(item.price);
+        row.appendChild(priceCell);
+
+        const subtotal = item.price * item.quantity;
+        total += subtotal;
+        const subtotalCell = document.createElement('td');
+        subtotalCell.textContent = peso.format(subtotal);
+        row.appendChild(subtotalCell);
+
+        const removeCell = document.createElement('td');
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn btn-muted btn-small';
+        removeBtn.textContent = 'Remove';
+        removeBtn.addEventListener('click', () => {
+          selectedItems.delete(id);
+          renderSelectedItems();
+        });
+        removeCell.appendChild(removeBtn);
+        row.appendChild(removeCell);
+
+        summaryBody.appendChild(row);
+      });
+    }
+
+    orderTotalLabel.textContent = peso.format(total);
+    if (!paymentAmountTouched || paymentStatusSelect.value === 'Paid') {
+      paymentAmountInput.value = total.toFixed(2);
+    }
+  }
+
+  async function fetchProducts(term) {
+    try {
+      const response = await callApi({
+        action: 'search_products',
+        query: term,
+        limit: '20',
+        in_stock_only: inStockOnlyCheckbox.checked ? '1' : '0'
+      });
+      renderProductResults(response.products || []);
+    } catch (error) {
+      console.error(error);
+      renderProductResults([]);
+    }
+  }
+
+  async function fetchCustomers(term) {
+    if (term.length === 0) {
+      customerResults.innerHTML = '';
+      return;
+    }
+    try {
+      const response = await callApi({ action: 'search_customers', query: term, limit: '10' });
+      renderCustomerResults(response.customers || []);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  function renderCustomerResults(customers) {
+    customerResults.innerHTML = '';
+    if (!customers.length) {
+      const empty = document.createElement('li');
+      empty.className = 'empty-state';
+      empty.textContent = 'No customers found.';
+      customerResults.appendChild(empty);
+      return;
+    }
+    customers.forEach((customer) => {
+      const item = document.createElement('li');
+      item.className = 'search-result';
+      item.innerHTML = `<strong>${customer.name}</strong><span>${customer.email || 'No email on file'}</span>`;
+      item.addEventListener('click', () => {
+        selectedCustomer = customer;
+        customerResults.innerHTML = '';
+        renderCustomerSummary();
+      });
+      customerResults.appendChild(item);
+    });
+  }
+
+  async function callApi(params) {
+    const body = new URLSearchParams(params);
+    body.set('csrf_token', csrfToken);
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+      },
+      body
+    });
+    const text = await response.text();
+    let json;
+    try {
+      json = JSON.parse(text);
+    } catch (error) {
+      throw new Error(text || 'Unexpected response from server.');
+    }
+    if (!response.ok) {
+      throw new Error(json.message || 'Request failed.');
+    }
+    return json;
+  }
+
+  async function submitForm(event) {
+    event.preventDefault();
+    clearMessage(formErrors);
+    clearMessage(messages);
+
+    const mode = form.querySelector('input[name="customer_mode"]:checked')?.value || 'existing';
+    if (mode === 'existing' && !selectedCustomer) {
+      setMessage(formErrors, 'error', 'Select a customer before posting the order.');
+      return;
+    }
+    if (mode === 'new') {
+      if (newCustomerName.value.trim() === '') {
+        setMessage(formErrors, 'error', 'Customer name is required.');
+        newCustomerName.focus();
+        return;
+      }
+      if (newCustomerEmail.value.trim() && !/^.+@.+\..+$/.test(newCustomerEmail.value.trim())) {
+        setMessage(formErrors, 'error', 'Enter a valid email address or leave it blank.');
+        newCustomerEmail.focus();
+        return;
+      }
+      if (fulfillmentTypeSelect.value === 'Delivery' && newCustomerAddress.value.trim() === '') {
+        setMessage(formErrors, 'error', 'Provide a delivery address for delivery orders.');
+        newCustomerAddress.focus();
+        return;
+      }
+    }
+    if (!selectedItems.size) {
+      setMessage(formErrors, 'error', 'Add at least one product to the order.');
+      return;
+    }
+
+    const items = Array.from(selectedItems.values()).map((item) => ({
+      product_id: item.id,
+      quantity: item.quantity
+    }));
+
+    const payload = {
+      action: 'create_order',
+      customer_mode: mode,
+      fulfillment_type: fulfillmentTypeSelect.value,
+      order_status: orderStatusSelect.value,
+      payment_method: paymentMethodSelect.value,
+      payment_status: paymentStatusSelect.value,
+      payment_amount: paymentAmountInput.value || '0',
+      reference_number: referenceNumberInput.value.trim(),
+      items: JSON.stringify(items)
+    };
+
+    if (mode === 'existing' && selectedCustomer) {
+      payload.user_id = String(selectedCustomer.id);
+    } else if (mode === 'new') {
+      payload.customer_name = newCustomerName.value.trim();
+      payload.customer_email = newCustomerEmail.value.trim();
+      payload.customer_address = newCustomerAddress.value.trim();
+    }
+
+    try {
+      const result = await callApi(payload);
+      if (!result.success) {
+        throw new Error(result.message || 'Failed to create order.');
+      }
+
+      clearMessage(formErrors);
+      messages.innerHTML = '';
+      messages.classList.remove('is-error');
+      messages.classList.add('is-success');
+      messages.classList.remove('is-hidden');
+
+      const successText = document.createElement('p');
+      successText.innerHTML = `Order <strong>#${String(result.order_id).padStart(5, '0')}</strong> created successfully.`;
+      messages.appendChild(successText);
+
+      const linkParagraph = document.createElement('p');
+      const orderLink = document.createElement('a');
+      orderLink.href = ordersUrl;
+      orderLink.textContent = 'Go to Manage Orders';
+      orderLink.className = 'link-order';
+      linkParagraph.appendChild(orderLink);
+      messages.appendChild(linkParagraph);
+
+      selectedItems.clear();
+      renderSelectedItems();
+
+      if (mode === 'existing') {
+        selectedCustomer = null;
+        renderCustomerSummary();
+        customerSearchInput.value = '';
+      } else {
+        newCustomerName.value = '';
+        newCustomerEmail.value = '';
+        newCustomerAddress.value = '';
+      }
+
+      paymentAmountInput.value = '0.00';
+      paymentAmountTouched = false;
+      referenceNumberInput.value = '';
+      orderStatusSelect.value = 'Pending';
+      paymentStatusSelect.value = 'Paid';
+      paymentMethodSelect.value = 'Cash';
+    } catch (error) {
+      console.error(error);
+      setMessage(messages, 'error', error.message || 'Something went wrong while creating the order.');
+    }
+  }
+
+  function toggleCustomerSections(mode) {
+    if (mode === 'existing') {
+      existingSection.classList.remove('is-hidden');
+      newSection.classList.add('is-hidden');
+      customerSearchInput.disabled = false;
+      newCustomerName.disabled = true;
+      newCustomerEmail.disabled = true;
+      newCustomerAddress.disabled = true;
+      customerSearchInput.focus();
+    } else {
+      existingSection.classList.add('is-hidden');
+      newSection.classList.remove('is-hidden');
+      customerSearchInput.disabled = true;
+      newCustomerName.disabled = false;
+      newCustomerEmail.disabled = false;
+      newCustomerAddress.disabled = false;
+      customerResults.innerHTML = '';
+      selectedCustomer = null;
+      renderCustomerSummary();
+      newCustomerName.focus();
+    }
+  }
+
+  customerModeRadios.forEach((radio) => {
+    radio.addEventListener('change', () => {
+      toggleCustomerSections(radio.value);
+    });
+  });
+
+  customerSearchInput.addEventListener('input', () => {
+    if (customerSearchTimer) {
+      clearTimeout(customerSearchTimer);
+    }
+    const term = customerSearchInput.value.trim();
+    customerSearchTimer = setTimeout(() => fetchCustomers(term), 250);
+  });
+
+  productSearchInput.addEventListener('input', () => {
+    if (productSearchTimer) {
+      clearTimeout(productSearchTimer);
+    }
+    const term = productSearchInput.value.trim();
+    productSearchTimer = setTimeout(() => fetchProducts(term), 200);
+  });
+
+  inStockOnlyCheckbox.addEventListener('change', () => {
+    fetchProducts(productSearchInput.value.trim());
+  });
+
+  paymentStatusSelect.addEventListener('change', () => {
+    if (paymentStatusSelect.value === 'Paid' && !paymentAmountTouched) {
+      const total = Array.from(selectedItems.values()).reduce((sum, item) => sum + item.price * item.quantity, 0);
+      paymentAmountInput.value = total.toFixed(2);
+    } else if (!paymentAmountTouched) {
+      paymentAmountInput.value = '0.00';
+    }
+  });
+
+  paymentAmountInput.addEventListener('input', () => {
+    paymentAmountTouched = true;
+  });
+
+  form.addEventListener('submit', submitForm);
+
+  toggleCustomerSections('existing');
+  renderSelectedItems();
+  renderCustomerSummary();
+  fetchProducts('');
+})();
+</script>
+JS;
+
+$extraScripts = sprintf($scriptTemplate, $csrfTokenJson, $apiUrlJson, $ordersUrlJson);
+
+include 'includes/footer.php';


### PR DESCRIPTION
## Summary
- add Source and Fulfillment_Type tracking to the order schema, sample data, and provide a migration for existing databases
- update order APIs and the admin orders table to persist and display the new metadata
- build a walk-in order admin workflow with supporting API endpoints, UI, and styling for staff to create in-store tickets

## Testing
- php -l PHP/order_functions.php
- php -l PHP/order_api.php
- php -l adminSide/api/walkin_order_actions.php
- php -l adminSide/orders.php
- php -l adminSide/walkin-order.php
- php -l adminSide/includes/sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68d0d492f004832486d0e9b4f639f4af