### PR TITLE
Integrate backend functionality into user design pages

### DIFF
--- a/PHP/user_api.php
+++ b/PHP/user_api.php
@@ -96,12 +96,13 @@ switch ($action) {
         echo json_encode(['updated' => true]);
         break;
     case 'update_profile':
-        $firstName = $_POST['first_name'] ?? '';
-        $lastName = $_POST['last_name'] ?? '';
-        $email = $_POST['email'] ?? '';
+        $firstName = trim($_POST['first_name'] ?? '');
+        $lastName = trim($_POST['last_name'] ?? '');
+        $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
+        $address = trim($_POST['address'] ?? '');
 
-        if (!$firstName || !$lastName || !$email) {
+        if (!$firstName || !$email) {
             http_response_code(400);
             echo json_encode(['error' => 'Missing required fields']);
             break;
@@ -117,9 +118,10 @@ switch ($action) {
         $fullName = trim($firstName . ' ' . $lastName);
         $params = [
             ':name' => $fullName,
+            ':address' => $address !== '' ? $address : ($user['Address'] ?? ''),
             ':id' => $user['User_ID']
         ];
-        $sql = 'UPDATE user SET Name = :name';
+        $sql = 'UPDATE user SET Name = :name, Address = :address';
 
         if ($password) {
             $hashed = password_hash($password, PASSWORD_DEFAULT);
@@ -166,7 +168,8 @@ switch ($action) {
 
         echo json_encode([
             'message' => 'Profile updated successfully',
-            'face_image_path' => $existing
+            'face_image_path' => $existing,
+            'address' => $params[':address']
         ]);
         break;
     default:

--- a/UserSide-design/Menu.html
+++ b/UserSide-design/Menu.html
@@ -102,7 +102,7 @@
         <ul class="dropdown-menu" id="profileMenu">
           <li><a href="profile.html">View Profile</a></li>
           <li><a href="orders.html">Order History</a></li>
-          <li><a href="logout.html">Logout</a></li>
+          <li><a href="../userSide/LOGIN_SIGNUP/logout.html">Logout</a></li>
         </ul>
       </li>
     </ul>

--- a/UserSide-design/SignupPage.html
+++ b/UserSide-design/SignupPage.html
@@ -58,7 +58,7 @@ nav ul li a:hover {
   padding:2.5rem;
   border-radius:12px;
   box-shadow:0 6px 20px rgba(0,0,0,0.2);
-  max-width:400px;
+  max-width:420px;
   width:100%;
   display:flex;
   flex-direction:column;
@@ -67,18 +67,70 @@ nav ul li a:hover {
 .signup-box h2 { color:#d62828; text-align:center; margin-bottom:1rem; font-size:1.5rem; }
 
 .input-group { position:relative; display:flex; flex-direction:column; gap:6px; }
-.input-group input { padding:12px; border-radius:8px; border:1px solid #ccc; font-size:1rem; width:100%; transition:border-color 0.2s; }
-.input-group input:focus { border-color:#d62828; outline:none; }
+.input-group input,
+.input-group textarea,
+.input-group select {
+  padding:12px;
+  border-radius:8px;
+  border:1px solid #ccc;
+  font-size:1rem;
+  width:100%;
+  transition:border-color 0.2s;
+}
+.input-group input:focus,
+.input-group textarea:focus,
+.input-group select:focus {
+  border-color:#d62828;
+  outline:none;
+}
 
 .password-wrapper { position:relative; display:flex; align-items:center; }
 .password-wrapper input { flex:1; padding-right:40px; }
 .eye-icon { position:absolute; right:10px; cursor:pointer; width:24px; height:24px; fill:#666; transition:0.2s; }
 .eye-icon:hover { fill:#d62828; }
 
-button { width:100%; padding:12px; background:#d62828; color:#fff; border:none; border-radius:8px; font-weight:700; cursor:pointer; font-size:1rem; margin-top:8px; }
+button {
+  width:100%;
+  padding:12px;
+  background:#d62828;
+  color:#fff;
+  border:none;
+  border-radius:8px;
+  font-weight:700;
+  cursor:pointer;
+  font-size:1rem;
+  margin-top:8px;
+}
+button:disabled { opacity:0.7; cursor:not-allowed; }
 .note { font-size:0.85rem; color:#666; margin-top:8px; text-align:center; }
 .note a { color:#d62828; font-weight:600; text-decoration:none; }
 .small-btn { background:#fcbf49; color:#333; padding:6px 10px; font-size:0.9rem; border-radius:6px; margin-top:5px; width:auto; cursor:pointer; border:none; }
+.small-btn.secondary { background:#ffe8a1; }
+
+.camera-area {
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  align-items:center;
+}
+.camera-area video,
+.camera-area img {
+  width:100%;
+  max-height:220px;
+  border-radius:12px;
+  border:2px dashed #d62828;
+  object-fit:cover;
+}
+.camera-area img { display:none; }
+.capture-actions { display:flex; gap:10px; justify-content:center; width:100%; flex-wrap:wrap; }
+
+#errorMessage {
+  color:#d62828;
+  font-size:0.85rem;
+  text-align:center;
+  min-height:1.4rem;
+}
+.success-message { color:#1b5e20; }
 </style>
 </head>
 <body>
@@ -92,7 +144,7 @@ button { width:100%; padding:12px; background:#d62828; color:#fff; border:none; 
       <li><a href="login.html">Login</a></li>
       <li><a href="home.html#about">About</a></li>
       <li><a href="home.html#visit">Contacts</a></li>
-      <li><a href="signup.html" class="active">Signup</a></li>
+      <li><a href="SignupPage.html" class="active">Signup</a></li>
     </ul>
   </nav>
 </header>
@@ -100,70 +152,61 @@ button { width:100%; padding:12px; background:#d62828; color:#fff; border:none; 
 <div class="main">
   <div class="signup-box">
     <h2>Sign Up</h2>
-    <form id="signupForm" action="signup-process.php" method="post">
+    <form id="signupForm" novalidate>
       <div class="input-group">
-        <label>First Name</label>
-        <input id="fname" name="fname" required>
+        <label for="fname">First Name</label>
+        <input id="fname" name="fname" autocomplete="given-name" required>
       </div>
       <div class="input-group">
-        <label>Last Name</label>
-        <input id="lname" name="lname" required>
+        <label for="lname">Last Name</label>
+        <input id="lname" name="lname" autocomplete="family-name" required>
       </div>
       <div class="input-group">
-        <label>Email</label>
-        <input id="email" name="email" type="email" required>
-        <button type="button" class="small-btn" id="sendCodeBtn">Send Verification Code</button>
-        <input id="emailCode" name="emailCode" type="text" placeholder="Enter verification code" style="display:none;" required>
+        <label for="email">Email</label>
+        <input id="email" name="email" type="email" autocomplete="email" required>
       </div>
       <div class="input-group">
-        <label>Password</label>
+        <label for="password">Password</label>
         <div class="password-wrapper">
-          <input id="password" name="password" type="password" required>
+          <input id="password" name="password" type="password" autocomplete="new-password" required>
           <svg id="eyeIcon" class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d="M12 5C7 5 2.73 8.11 1 12c1.73 3.89 6 7 11 7s9.27-3.11 11-7c-1.73-3.89-6-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10z"/>
           </svg>
         </div>
       </div>
       <div class="input-group">
-        <label>Confirm Password</label>
+        <label for="confirmPassword">Confirm Password</label>
         <div class="password-wrapper">
-          <input id="confirmPassword" name="confirmPassword" type="password" required>
+          <input id="confirmPassword" name="confirmPassword" type="password" autocomplete="new-password" required>
           <svg id="eyeIcon2" class="eye-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d="M12 5C7 5 2.73 8.11 1 12c1.73 3.89 6 7 11 7s9.27-3.11 11-7c-1.73-3.89-6-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10z"/>
           </svg>
         </div>
       </div>
+
+      <div class="input-group">
+        <label>Face Capture</label>
+        <div class="camera-area">
+          <video id="video" autoplay playsinline muted></video>
+          <img id="capturedImage" alt="Captured face preview">
+          <div class="capture-actions">
+            <button type="button" class="small-btn" id="captureBtn">Capture Face</button>
+            <button type="button" class="small-btn secondary" id="retakeBtn" style="display:none;">Retake</button>
+          </div>
+        </div>
+      </div>
+
+      <input type="hidden" id="faceImage" name="faceImage">
+      <div id="errorMessage"></div>
       <button type="submit">Register</button>
     </form>
-    <div class="note">Please verify your email and confirm your password before registering.</div>
+    <div class="note">Please capture your face and use a strong password before registering.</div>
   </div>
 </div>
 
 <script>
-const sendCodeBtn = document.getElementById('sendCodeBtn');
-const emailInput = document.getElementById('email');
-const emailCodeInput = document.getElementById('emailCode');
-let generatedCode = null;
+function toggleMenu() { document.getElementById("navMenu").classList.toggle("active"); }
 
-// Email verification demo
-sendCodeBtn.addEventListener('click', () => {
-  if (!emailInput.value) { alert('Enter your email first'); return; }
-  generatedCode = Math.floor(100000 + Math.random() * 900000).toString();
-  emailCodeInput.style.display = 'block';
-  alert("Demo verification code for " + emailInput.value + " is: " + generatedCode);
-});
-
-// Password confirm check
-document.getElementById('signupForm').addEventListener('submit', e => {
-  const pass = document.getElementById('password').value;
-  const confirmPass = document.getElementById('confirmPassword').value;
-  const enteredCode = emailCodeInput.value;
-  if (pass !== confirmPass) { e.preventDefault(); alert("Passwords do not match!"); return; }
-  if (!generatedCode || enteredCode !== generatedCode) { e.preventDefault(); alert("Invalid or missing email verification code!"); return; }
-  alert("✅ Demo signup successful with verified email!");
-});
-
-// Show/hide passwords
 const passwordInput = document.getElementById("password");
 const eyeIcon = document.getElementById("eyeIcon");
 eyeIcon.addEventListener("click", () => {
@@ -179,9 +222,159 @@ eyeIcon2.addEventListener("click", () => {
   confirmInput.type = type;
   eyeIcon2.style.fill = type === "text" ? "#d62828" : "#666";
 });
+</script>
 
-// Hamburger toggle
-function toggleMenu() { document.getElementById("navMenu").classList.toggle("active"); }
+<script type="module">
+import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { getAuth, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+
+const form = document.getElementById('signupForm');
+const captureBtn = document.getElementById('captureBtn');
+const retakeBtn = document.getElementById('retakeBtn');
+const video = document.getElementById('video');
+const capturedImage = document.getElementById('capturedImage');
+const faceInput = document.getElementById('faceImage');
+const errorBox = document.getElementById('errorMessage');
+const submitBtn = form.querySelector('button[type="submit"]');
+let stream = null;
+
+function setError(message, isSuccess = false) {
+  errorBox.textContent = message || '';
+  errorBox.classList.toggle('success-message', isSuccess);
+}
+
+async function ensureFirebase() {
+  if (!getApps().length) {
+    const configUrl = new URL('../PHP/firebase_config.php', import.meta.url);
+    const response = await fetch(configUrl, { credentials: 'same-origin' });
+    if (!response.ok) {
+      throw new Error(`Unable to load Firebase configuration: ${response.status}`);
+    }
+    const config = await response.json();
+    initializeApp(config);
+  }
+  return getAuth();
+}
+
+function isStrongPassword(pw) {
+  const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+  return regex.test(pw);
+}
+
+async function startCamera() {
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    video.srcObject = stream;
+  } catch (err) {
+    console.error('Camera access denied:', err);
+    setError('Camera access is required to capture your face.');
+  }
+}
+
+function captureFace() {
+  if (!video.videoWidth) {
+    setError('Camera is still loading. Please try again in a moment.');
+    return;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+  const imageData = canvas.toDataURL('image/png');
+  faceInput.value = imageData;
+  capturedImage.src = imageData;
+  capturedImage.style.display = 'block';
+  video.style.display = 'none';
+  retakeBtn.style.display = 'inline-flex';
+  captureBtn.textContent = 'Face Captured';
+  captureBtn.disabled = true;
+  setError('Face captured successfully.', true);
+}
+
+function retakeFace() {
+  faceInput.value = '';
+  capturedImage.src = '';
+  capturedImage.style.display = 'none';
+  video.style.display = 'block';
+  captureBtn.textContent = 'Capture Face';
+  captureBtn.disabled = false;
+  retakeBtn.style.display = 'none';
+  setError('');
+}
+
+captureBtn.addEventListener('click', captureFace);
+retakeBtn.addEventListener('click', retakeFace);
+startCamera();
+
+ensureFirebase()
+  .then(auth => {
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      setError('');
+
+      const firstName = form.fname.value.trim();
+      const lastName = form.lname.value.trim();
+      const email = form.email.value.trim();
+      const password = form.password.value;
+      const confirmPassword = form.confirmPassword.value;
+      const faceImage = faceInput.value;
+
+      if (!firstName || !lastName) {
+        setError('Please enter your full name.');
+        return;
+      }
+      if (!isStrongPassword(password)) {
+        setError('Password must be at least 8 characters and include uppercase, lowercase, number, and symbol.');
+        return;
+      }
+      if (password !== confirmPassword) {
+        setError('Passwords do not match.');
+        return;
+      }
+      if (!faceImage) {
+        setError('Please capture your face before signing up.');
+        return;
+      }
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Creating account…';
+
+      try {
+        await createUserWithEmailAndPassword(auth, email, password);
+        const fullName = `${firstName} ${lastName}`.trim();
+        const response = await fetch('../PHP/register_user.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fullName, email, password, faceImage })
+        });
+        const data = await response.json();
+        if (!response.ok || !data.success) {
+          throw new Error(data.error || 'Failed to save user information.');
+        }
+        setError('Account created successfully! Redirecting to login…', true);
+        setTimeout(() => {
+          window.location.href = 'login.html';
+        }, 1200);
+      } catch (err) {
+        console.error('Signup failed:', err);
+        setError(err.message || 'Unable to create account. Please try again.');
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Register';
+      }
+    });
+  })
+  .catch(err => {
+    console.error('Firebase init failed:', err);
+    setError('Unable to connect to authentication service. Please try again later.');
+    submitBtn.disabled = true;
+  });
+
+window.addEventListener('beforeunload', () => {
+  if (stream) {
+    stream.getTracks().forEach(track => track.stop());
+  }
+});
 </script>
 
 </body>

--- a/UserSide-design/checkout.html
+++ b/UserSide-design/checkout.html
@@ -11,346 +11,164 @@
 
     header {
       background: #8B4513; color: #fff;
-      padding: 1rem 2rem; display: flex; justify-content: space-between; align-items: center;
+      padding: 1rem 2rem; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;
     }
     header h1 { font-size: 1.4rem; }
-    nav a { color: #fff; margin-left: 1rem; text-decoration: none; font-weight: 500; }
-    nav a:hover { text-decoration: underline; }
+    nav a { color: #fff; margin-left: 1rem; text-decoration: none; font-weight: 500; padding: 0.4rem 0.8rem; border-radius: 999px; }
+    nav a:hover, nav a.active { background: rgba(255,255,255,0.25); }
 
     .container {
       max-width: 1200px; margin: 2rem auto; padding: 0 1rem;
       display: grid; grid-template-columns: 2fr 1fr; gap: 1.5rem;
     }
     .section {
-      background: #fff; border-radius: 12px; padding: 1.5rem;
-      box-shadow: 0 3px 10px rgba(0,0,0,0.08); margin-bottom: 1rem;
+      background: #fff; border-radius: 14px; padding: 1.8rem;
+      box-shadow: 0 8px 20px rgba(0,0,0,0.08); margin-bottom: 1rem;
     }
-    h2 { color: #8B4513; font-size: 1.2rem; margin-bottom: 1rem; }
+    h2 { color: #8B4513; font-size: 1.25rem; margin-bottom: 1rem; }
 
-    /* Cart */
-    .cart-item { display: flex; justify-content: space-between; align-items: center;
-      padding: 0.5rem 0; border-bottom: 1px solid #eee; }
-    .cart-item:last-child { border-bottom: none; }
-    .item-controls { display: flex; align-items: center; gap: 5px; }
-    .qty-btn {
-      background: #8B4513; color: #fff; border: none; border-radius: 4px;
-      width: 25px; height: 25px; cursor: pointer; font-size: 1rem;
-    }
-    .remove-btn {
-      background: crimson; color: #fff; border: none; border-radius: 4px;
-      padding: 3px 7px; font-size: 0.8rem; cursor: pointer;
-    }
-    .cart-total { font-weight: bold; text-align: right; margin-top: 0.8rem;
-      font-size: 1.1rem; color: #d2691e; }
-
-    /* Customer Info */
-    label { display: block; font-weight: 600; margin: 0.8rem 0 0.3rem; }
+    label { display: block; font-weight: 600; margin: 0.8rem 0 0.3rem; color: #8B4513; }
     input, select, textarea {
-      width: 100%; padding: 0.7rem; border: 1px solid #ddd; border-radius: 8px;
-      margin-bottom: 0.5rem; font-size: 0.9rem;
+      width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 10px;
+      margin-bottom: 0.4rem; font-size: 0.95rem;
     }
+    textarea { resize: none; min-height: 80px; }
 
-    /* Profile Button */
     .profile-btn {
-      background: #f4e1d2; border: 1px solid #ccc; border-radius: 8px;
+      background: #f4e1d2; border: 1px solid #d7b89c; border-radius: 10px;
       padding: 0.8rem; margin-bottom: 1rem; cursor: pointer;
-      width: 100%; text-align: left; font-size: 0.9rem;
+      width: 100%; text-align: left; font-size: 0.9rem; font-weight: 600; color:#6f3d18;
     }
     .profile-btn:hover { background: #ecd5c2; }
 
-    /* Confirm Button */
+    .cart-controls { display:flex; justify-content: space-between; align-items:center; margin-bottom: 0.8rem; font-size:0.9rem; color:#8B4513; }
+    .cart-item { display:flex; justify-content:space-between; align-items:center; padding:0.8rem 0; border-bottom:1px solid #eee; gap:0.8rem; }
+    .cart-item:last-child { border-bottom:none; }
+    .item-info { display:flex; align-items:center; gap:0.8rem; flex:1; }
+    .item-info img { width:70px; height:70px; object-fit:cover; border-radius:12px; border:1px solid #f1e2d3; }
+    .item-details { display:flex; flex-direction:column; gap:0.3rem; }
+    .item-name { font-weight:600; }
+    .item-price { font-size:0.9rem; color:#a5672d; }
+    .item-controls { display:flex; align-items:center; gap:0.4rem; }
+    .qty-btn {
+      background: #8B4513; color: #fff; border: none; border-radius: 6px;
+      width: 28px; height: 28px; cursor: pointer; font-size: 1rem; display:flex; align-items:center; justify-content:center;
+    }
+    .qty-display { min-width: 24px; text-align: center; font-weight:600; }
+    .remove-btn {
+      background: #d9534f; color: #fff; border: none; border-radius: 6px;
+      padding: 0.4rem 0.6rem; font-size: 0.75rem; cursor: pointer;
+    }
+    .remove-btn:hover { background:#c13d39; }
+
+    .cart-total { font-weight: 600; text-align: right; margin-top: 0.8rem;
+      font-size: 1rem; color: #d2691e; }
+
     .confirm-btn {
       display: block; width: 100%; background: #8B4513; color: #fff;
-      padding: 0.9rem; border: none; border-radius: 10px;
+      padding: 0.95rem; border: none; border-radius: 12px;
       font-weight: 600; font-size: 1rem; cursor: pointer;
       margin-top: 1rem; transition: background 0.2s;
     }
     .confirm-btn:hover { background: #a0522d; }
+    .confirm-btn:disabled { opacity:0.6; cursor:not-allowed; }
 
-    /* Popup */
+    .info-text { font-size:0.85rem; color:#b3261e; margin-top:0.5rem; min-height:1rem; text-align:center; }
+
     .popup {
       position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-      background: rgba(0,0,0,0.5); display: flex; align-items: center;
-      justify-content: center; display: none;
+      background: rgba(0,0,0,0.5); display: none; align-items: center;
+      justify-content: center; padding:1rem;
     }
     .popup-content {
-      background: #fff; padding: 1.5rem; border-radius: 12px;
-      text-align: left; max-width: 500px; width: 90%;
-      max-height: 80vh; overflow-y: auto;
-      box-shadow: 0 5px 20px rgba(0,0,0,0.2);
+      background: #fff; padding: 1.8rem; border-radius: 16px;
+      text-align: left; max-width: 520px; width: 100%;
+      max-height: 85vh; overflow-y: auto; box-shadow: 0 6px 24px rgba(0,0,0,0.2);
     }
     .popup-content h3 { color: #8B4513; margin-bottom: 1rem; text-align: center; }
     .popup-content ul { list-style: none; padding: 0; margin: 0; }
-    .popup-content li { padding: 0.5rem; border-bottom: 1px solid #eee; cursor: pointer; }
-    .popup-content li:hover { background: #f4e1d2; }
+    .popup-content li { padding: 0.4rem 0; border-bottom: 1px solid #eee; font-size:0.95rem; }
+    .popup-content li:last-child { border-bottom:none; }
     .ok-btn {
-      display: block; margin: 1rem auto 0; padding: 0.6rem 1.2rem;
-      background: #8B4513; color: #fff; border: none; border-radius: 8px;
+      display: block; margin: 1rem auto 0; padding: 0.7rem 1.4rem;
+      background: #8B4513; color: #fff; border: none; border-radius: 10px;
       cursor: pointer; font-weight: 600;
     }
+    .ok-btn:hover { background:#a0522d; }
 
-    @media(max-width: 768px) {
+    @media(max-width: 900px) {
       .container { grid-template-columns: 1fr; }
     }
-
-
-    /* --- Add Address Popup Styling --- */
-  .popup-content.add-popup {
-    background: #fff;
-    border-radius: 12px;
-    padding: 1.8rem;
-    width: 100%;
-    max-width: 420px;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.15);
-    animation: fadeIn 0.25s ease-in-out;
-  }
-  .popup-content.add-popup h3 {
-    margin-bottom: 1.2rem;
-    font-size: 1.3rem;
-    color: #8B4513;
-    text-align: center;
-  }
-  .form-group { margin-bottom: 1rem; }
-  .form-group label {
-    display: block;
-    font-size: 0.9rem;
-    margin-bottom: 0.3rem;
-    color: #444;
-    font-weight: 500;
-  }
-  .form-group input,
-  .form-group textarea {
-    width: 100%;
-    padding: 0.75rem;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    font-size: 0.95rem;
-    transition: border-color 0.2s;
-  }
-  .form-group input:focus,
-  .form-group textarea:focus {
-    outline: none;
-    border-color: #8B4513;
-  }
-  textarea {
-    resize: none;
-    height: 80px;
-  }
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.8rem;
-    margin-top: 1rem;
-  }
-  .btn {
-    padding: 0.6rem 1.2rem;
-    border: none;
-    border-radius: 8px;
-    font-size: 0.95rem;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  .btn.cancel {
-    background: #eaeaea;
-    color: #333;
-  }
-  .btn.cancel:hover { background: #d6d6d6; }
-  .btn.save {
-    background: #8B4513;
-    color: white;
-    font-weight: 500;
-  }
-  .btn.save:hover { background: #a0522d; }
-
-  @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-10px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-   .popup-content.add-popup {
-    background: #fff;
-    border-radius: 12px;
-    padding: 1.8rem;
-    width: 100%;
-    max-width: 420px;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.15);
-    animation: fadeIn 0.25s ease-in-out;
-  }
-  .popup-content.add-popup h3 {
-    margin-bottom: 1.2rem;
-    font-size: 1.3rem;
-    color: #8B4513;
-    text-align: center;
-  }
-  .form-group { margin-bottom: 1rem; }
-  .form-group label {
-    display: block;
-    font-size: 0.9rem;
-    margin-bottom: 0.3rem;
-    color: #444;
-    font-weight: 500;
-  }
-  .form-group input,
-  .form-group textarea {
-    width: 100%;
-    padding: 0.75rem;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    font-size: 0.95rem;
-    transition: border-color 0.2s;
-  }
-  .form-group input:focus,
-  .form-group textarea:focus {
-    outline: none;
-    border-color: #8B4513;
-  }
-  textarea {
-    resize: none;
-    height: 80px;
-  }
-  .error {
-    display: block;
-    font-size: 0.8rem;
-    color: red;
-    margin-top: 4px;
-  }
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.8rem;
-    margin-top: 1rem;
-  }
-  .btn {
-    padding: 0.6rem 1.2rem;
-    border: none;
-    border-radius: 8px;
-    font-size: 0.95rem;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  .btn.cancel {
-    background: #eaeaea;
-    color: #333;
-  }
-  .btn.cancel:hover { background: #d6d6d6; }
-  .btn.save {
-    background: #8B4513;
-    color: white;
-    font-weight: 500;
-  }
-  .btn.save:hover { background: #a0522d; }
-
-  @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-10px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
   </style>
 </head>
 <body>
   <header>
     <h1>🥖 Cindy’s Bakeshop</h1>
     <nav>
-      <a href="index.html">Home</a>
+      <a href="home.html">Home</a>
       <a href="Menu.html">Menu</a>
-      <a href="checkout.html">Cart</a>
-      <a href="contact.html">Contact</a>
+      <a href="checkout.html" class="active">Cart</a>
+      <a href="orders.html">Orders</a>
+      <a href="profile.html">Profile</a>
     </nav>
   </header>
 
   <div class="container">
-    <!-- Left -->
+    <!-- Customer Information -->
     <div>
       <div class="section">
         <h2>Customer Information</h2>
 
-        <!-- 🔹 Profile Button -->
-        <button class="profile-btn" id="profileBtn">
-          ➕ Select or Add Address
-        </button>
+        <button class="profile-btn" id="profileBtn">↺ Load saved profile details</button>
 
         <label for="name">Full Name</label>
-        <input type="text" id="name">
+        <input type="text" id="name" placeholder="Juan Dela Cruz">
+
         <label for="phone">Phone Number</label>
-        <input type="text" id="phone">
+        <input type="text" id="phone" placeholder="09xxxxxxxxx">
 
         <label for="orderType">Order Type</label>
         <select id="orderType">
-          <option value="pickup">Pickup</option>
-          <option value="delivery">Delivery</option>
+          <option value="">-- Select --</option>
+          <option value="Pickup">Pickup</option>
+          <option value="Delivery">Delivery</option>
         </select>
 
         <div id="addressSection" style="display:none;">
           <label for="address">Delivery Address</label>
-          <textarea id="address" rows="2"></textarea>
+          <textarea id="address" rows="3" placeholder="House No., Street, Barangay, City"></textarea>
         </div>
 
         <label for="payment">Payment Method</label>
-        <select id="payment">
-          <option value="cod">Cash on Delivery/Pickup</option>
-          <option value="gcash">GCash</option>
-          <option value="card">Credit/Debit Card</option>
+        <select id="payment" disabled>
+          <option value="">-- Select --</option>
         </select>
 
         <label for="notes">Order Notes</label>
-        <textarea id="notes" rows="2"></textarea>
+        <textarea id="notes" rows="2" placeholder="Add any special requests"></textarea>
       </div>
     </div>
 
-    <!-- Right -->
+    <!-- Cart Summary -->
     <div>
       <div class="section">
         <h2>Your Cart</h2>
+        <div class="cart-controls">
+          <label><input type="checkbox" id="selectAll" checked> Select All</label>
+          <span id="cartCount">0 items selected</span>
+        </div>
         <div id="cartItems"></div>
-        <div class="cart-total" id="cartTotal">Total: ₱0</div>
+        <div class="cart-total" id="cartTotal">Total: ₱0.00</div>
       </div>
-      <button class="confirm-btn" id="confirmBtn">✅ Confirm Order</button>
+      <button class="confirm-btn" id="confirmBtn" disabled>✅ Place Order</button>
+      <div class="info-text" id="checkoutMessage"></div>
     </div>
   </div>
 
-  <!-- Address List Popup -->
-  <div class="popup" id="addressPopup">
+  <!-- Order Summary Popup -->
+  <div class="popup" id="summaryPopup">
     <div class="popup-content">
-      <h3>Select Address</h3>
-      <ul id="addressList"></ul>
-      <button class="ok-btn" onclick="openAddAddress()">➕ Add New Address</button>
-      <button class="ok-btn" onclick="closeAddressPopup()">Close</button>
-    </div>
-  </div>
-
-  <!-- Add Address Popup -->
-<div class="popup" id="addAddressPopup">
-  <div class="popup-content add-popup">
-    <h3>Add New Address</h3>
-
-    <div class="form-group">
-      <label for="newName">Full Name</label>
-      <input type="text" id="newName" placeholder="Enter full name">
-      <small class="error" id="nameError"></small>
-    </div>
-
-    <div class="form-group">
-      <label for="newPhone">Phone Number</label>
-      <input type="text" id="newPhone" placeholder="09xxxxxxxxx">
-      <small class="error" id="phoneError"></small>
-    </div>
-
-    <div class="form-group">
-      <label for="newAddress">Address</label>
-      <textarea id="newAddress" placeholder="House No., Street, Barangay, City"></textarea>
-      <small class="error" id="addressError"></small>
-    </div>
-
-    <div class="actions">
-      <button class="btn cancel" onclick="closeAddAddress()">Cancel</button>
-      <button class="btn save" onclick="saveNewAddress()">Save</button>
-    </div>
-  </div>
-</div>
-
-  <!-- Order Confirm Popup -->
-  <div class="popup" id="popup">
-    <div class="popup-content">
-      <h3>🎉 Order Confirmed!</h3>
+      <h3>🎉 Order Placed!</h3>
       <p><strong>Name:</strong> <span id="summaryName"></span></p>
       <p><strong>Phone:</strong> <span id="summaryPhone"></span></p>
       <p><strong>Order Type:</strong> <span id="summaryType"></span></p>
@@ -360,203 +178,410 @@
       <h4>🛒 Items</h4>
       <ul id="summaryItems"></ul>
       <p id="summaryTotal" style="font-weight:bold; color:#d2691e;"></p>
-      <p style="font-size:0.9rem; color:#555;">⏰ Estimated Time: <span id="summaryTime"></span></p>
-      <button class="ok-btn" onclick="closePopup()">OK</button>
+      <p id="summaryLink" style="text-align:center; margin-top:0.8rem;"></p>
+      <button class="ok-btn" id="summaryClose">OK</button>
     </div>
   </div>
 
-  <script>
-    let cart = JSON.parse(localStorage.getItem('cartData')) || [];
-    const cartItems = document.getElementById('cartItems');
-    const cartTotal = document.getElementById('cartTotal');
-    const orderType = document.getElementById('orderType');
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../userSide/firebase-init.js";
+
+    const cartItemsContainer = document.getElementById('cartItems');
+    const cartTotalEl = document.getElementById('cartTotal');
+    const cartCountEl = document.getElementById('cartCount');
+    const selectAllCheckbox = document.getElementById('selectAll');
+    const confirmBtn = document.getElementById('confirmBtn');
+    const profileBtn = document.getElementById('profileBtn');
+    const checkoutMessage = document.getElementById('checkoutMessage');
+
+    const nameInput = document.getElementById('name');
+    const phoneInput = document.getElementById('phone');
+    const addressInput = document.getElementById('address');
+    const orderTypeSelect = document.getElementById('orderType');
+    const paymentSelect = document.getElementById('payment');
     const addressSection = document.getElementById('addressSection');
-    const addressBox = document.getElementById('address');
+    const notesInput = document.getElementById('notes');
 
-    // ✅ Saved Profiles
-    let savedProfiles = [
-      { name: "Juan Dela Cruz", phone: "09123456789", address: "123 Street, Barangay, City" },
-      { name: "Juan Dela Cruz", phone: "09987654321", address: "456 Avenue, Business District" }
-    ];
-    let currentProfile = null;
+    const summaryPopup = document.getElementById('summaryPopup');
+    const summaryClose = document.getElementById('summaryClose');
+    const summaryName = document.getElementById('summaryName');
+    const summaryPhone = document.getElementById('summaryPhone');
+    const summaryType = document.getElementById('summaryType');
+    const summaryAddressWrap = document.getElementById('summaryAddressWrap');
+    const summaryAddress = document.getElementById('summaryAddress');
+    const summaryPayment = document.getElementById('summaryPayment');
+    const summaryNotes = document.getElementById('summaryNotes');
+    const summaryItems = document.getElementById('summaryItems');
+    const summaryTotal = document.getElementById('summaryTotal');
+    const summaryLink = document.getElementById('summaryLink');
 
-    // 🔹 Profile Button
-    const profileBtn = document.getElementById("profileBtn");
-    const addressPopup = document.getElementById("addressPopup");
-    const addressList = document.getElementById("addressList");
+    const auth = getAuth();
+    let userEmail = null;
+    let currentCart = [];
+    let currentProfile = { name: '', address: '' };
 
-    profileBtn.addEventListener("click", () => {
-      renderAddressList();
-      addressPopup.style.display = "flex";
+    function setMessage(text, type = 'error') {
+      checkoutMessage.textContent = text || '';
+      checkoutMessage.style.color = type === 'error' ? '#b3261e' : '#1b5e20';
+    }
+
+    function storedPhoneKey(email) {
+      return `userPhone:${email}`;
+    }
+
+    function loadStoredPhone(email) {
+      return localStorage.getItem(storedPhoneKey(email)) || '';
+    }
+
+    function saveStoredPhone(email, value) {
+      if (value) {
+        localStorage.setItem(storedPhoneKey(email), value);
+      } else {
+        localStorage.removeItem(storedPhoneKey(email));
+      }
+    }
+
+    function updatePaymentOptions() {
+      const type = orderTypeSelect.value;
+      paymentSelect.innerHTML = '<option value="">-- Select --</option>';
+      if (type === 'Delivery') {
+        paymentSelect.innerHTML += '<option value="GCash">GCash</option>';
+        paymentSelect.disabled = false;
+        addressSection.style.display = 'block';
+      } else if (type === 'Pickup') {
+        paymentSelect.innerHTML += '<option value="Cash on Pick Up">Cash on Pick Up</option>';
+        paymentSelect.innerHTML += '<option value="GCash">GCash</option>';
+        paymentSelect.disabled = false;
+        addressSection.style.display = 'none';
+      } else {
+        paymentSelect.disabled = true;
+        addressSection.style.display = 'none';
+      }
+    }
+
+    orderTypeSelect.addEventListener('change', updatePaymentOptions);
+
+    selectAllCheckbox.addEventListener('change', () => {
+      document.querySelectorAll('.item-check').forEach(cb => {
+        cb.checked = selectAllCheckbox.checked;
+      });
+      updateTotals();
     });
 
-    function renderAddressList() {
-      addressList.innerHTML = "";
-      savedProfiles.forEach((p, i) => {
-        const li = document.createElement("li");
-        li.textContent = `${p.name} | ${p.phone} | ${p.address}`;
-        li.onclick = () => selectProfile(i);
-        addressList.appendChild(li);
-      });
-    }
-
-    function selectProfile(index) {
-      currentProfile = savedProfiles[index];
-      document.getElementById("name").value = currentProfile.name;
-      document.getElementById("phone").value = currentProfile.phone;
-      orderType.value = "delivery";
-      addressSection.style.display = "block";
-      addressBox.value = currentProfile.address;
-      profileBtn.textContent = `${currentProfile.name} | ${currentProfile.phone} | ${currentProfile.address}`;
-      closeAddressPopup();
-    }
-
-    function closeAddressPopup() { addressPopup.style.display = "none"; }
-
-    // 🔹 Add Address Popup
-    const addAddressPopup = document.getElementById("addAddressPopup");
-    function openAddAddress() {
-      closeAddressPopup();
-      addAddressPopup.style.display = "flex";
-    }
-    function closeAddAddress() { addAddressPopup.style.display = "none"; }
-
-    function saveNewAddress() {
-      const name = document.getElementById("newName").value.trim();
-      const phone = document.getElementById("newPhone").value.trim();
-      const address = document.getElementById("newAddress").value.trim();
-      if (!name || !phone || !address) {
-        alert("Please fill all fields!");
+    profileBtn.addEventListener('click', () => {
+      if (!currentProfile.name && !currentProfile.address) {
+        setMessage('No saved profile information found.', 'error');
         return;
       }
-      savedProfiles.push({ name, phone, address });
-      closeAddAddress();
-    }
-
-
-     function saveNewAddress() {
-    let valid = true;
-
-    // Clear previous errors
-    document.getElementById("nameError").innerText = "";
-    document.getElementById("phoneError").innerText = "";
-    document.getElementById("addressError").innerText = "";
-
-    const name = document.getElementById("newName").value.trim();
-    const phone = document.getElementById("newPhone").value.trim();
-    const address = document.getElementById("newAddress").value.trim();
-
-    // Validate Name
-    if (name.length < 3) {
-      document.getElementById("nameError").innerText = "Name must be at least 3 characters.";
-      valid = false;
-    }
-
-    // Validate Phone (only digits, 11 characters, starts with 09)
-    if (!/^(09)\d{9}$/.test(phone)) {
-      document.getElementById("phoneError").innerText = "Enter a valid 11-digit number (e.g., 09xxxxxxxxx).";
-      valid = false;
-    }
-
-    // Validate Address
-    if (address.length < 5) {
-      document.getElementById("addressError").innerText = "Address must be at least 5 characters.";
-      valid = false;
-    }
-
-    if (!valid) return;
-
-    // ✅ If valid → add new address (replace with your own save logic)
-    alert("✅ New address saved:\n\n" + name + "\n" + phone + "\n" + address);
-    closeAddAddress();
-  }
-
-  function closeAddAddress() {
-    document.getElementById("addAddressPopup").style.display = "none";
-  }
-
-    // Cart Rendering
-    function renderCart() {
-      cartItems.innerHTML = '';
-      let total = 0;
-      cart.forEach((item, index) => {
-        total += item.price * item.qty;
-        const div = document.createElement('div');
-        div.classList.add('cart-item');
-        div.innerHTML = `
-          <div>${item.name} - ₱${item.price}</div>
-          <div class="item-controls">
-            <button class="qty-btn" onclick="updateQty(${index}, -1)">-</button>
-            <span>${item.qty}</span>
-            <button class="qty-btn" onclick="updateQty(${index}, 1)">+</button>
-            <button class="remove-btn" onclick="removeItem(${index})">X</button>
-          </div>`;
-        cartItems.appendChild(div);
-      });
-      cartTotal.textContent = `Total: ₱${total}`;
-    }
-
-    function updateQty(index, change) {
-      cart[index].qty += change;
-      if (cart[index].qty <= 0) cart.splice(index, 1);
-      saveAndRender();
-    }
-    function removeItem(index) { cart.splice(index, 1); saveAndRender(); }
-    function saveAndRender() {
-      localStorage.setItem('cartData', JSON.stringify(cart));
-      renderCart();
-    }
-
-    orderType.addEventListener('change', () => {
-      addressSection.style.display = orderType.value === 'delivery' ? 'block' : 'none';
+      nameInput.value = currentProfile.name || '';
+      addressInput.value = currentProfile.address || '';
+      if (userEmail) {
+        phoneInput.value = loadStoredPhone(userEmail) || '';
+      }
+      setMessage('Profile details applied.', 'success');
     });
 
-    // Confirm Order
-    document.getElementById('confirmBtn').addEventListener('click', () => {
-      const name = document.getElementById('name').value.trim();
-      const phone = document.getElementById('phone').value.trim();
-      const notes = document.getElementById('notes').value.trim();
-      const payment = document.getElementById('payment').value;
-      const address = addressBox.value.trim();
+    summaryClose.addEventListener('click', () => {
+      summaryPopup.style.display = 'none';
+    });
 
-      if (!name || !phone) { alert("Fill in your name and phone."); return; }
-      if (!/^09\d{9}$/.test(phone)) { alert("Invalid phone."); return; }
-      if (orderType.value === 'delivery' && !address) { alert("Enter address."); return; }
-      if (cart.length === 0) { alert("Your cart is empty!"); return; }
+    function createCartItemElement(item) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'cart-item';
+      wrapper.dataset.id = item.Cart_Item_ID;
+      wrapper.dataset.product = item.Product_ID;
+      wrapper.dataset.price = item.Price;
+      wrapper.dataset.stock = item.Stock_Quantity;
 
-      document.getElementById('summaryName').textContent = name;
-      document.getElementById('summaryPhone').textContent = phone;
-      document.getElementById('summaryType').textContent = orderType.value;
-      document.getElementById('summaryPayment').textContent = payment.toUpperCase();
-      document.getElementById('summaryNotes').textContent = notes || "None";
+      const imgSrc = item.Image_Path ? `../adminSide/products/uploads/${item.Image_Path}` : '../userSide/Images/cindy_s logo.png';
 
-      if (orderType.value === "delivery") {
-        document.getElementById('summaryAddressWrap').style.display = "block";
-        document.getElementById('summaryAddress').textContent = address;
-      } else {
-        document.getElementById('summaryAddressWrap').style.display = "none";
+      wrapper.innerHTML = `
+        <div class="item-info">
+          <input type="checkbox" class="item-check" checked>
+          <img src="${imgSrc}" alt="${item.Name}">
+          <div class="item-details">
+            <span class="item-name">${item.Name}</span>
+            <span class="item-price">₱${parseFloat(item.Price).toFixed(2)}</span>
+          </div>
+        </div>
+        <div class="item-controls">
+          <button class="qty-btn decrease-btn">-</button>
+          <span class="qty-display">${item.Quantity}</span>
+          <button class="qty-btn increase-btn">+</button>
+          <button class="remove-btn">Remove</button>
+        </div>
+      `;
+
+      const checkBox = wrapper.querySelector('.item-check');
+      checkBox.addEventListener('change', updateTotals);
+
+      wrapper.querySelector('.increase-btn').addEventListener('click', () => adjustQuantity(wrapper, 1));
+      wrapper.querySelector('.decrease-btn').addEventListener('click', () => adjustQuantity(wrapper, -1));
+      wrapper.querySelector('.remove-btn').addEventListener('click', () => removeItem(wrapper));
+
+      return wrapper;
+    }
+
+    function updateTotals() {
+      let total = 0;
+      let count = 0;
+      const items = Array.from(document.querySelectorAll('.cart-item'));
+      items.forEach(item => {
+        const checkbox = item.querySelector('.item-check');
+        if (checkbox.checked) {
+          const price = parseFloat(item.dataset.price);
+          const qty = parseInt(item.querySelector('.qty-display').textContent, 10);
+          total += price * qty;
+          count += qty;
+        }
+      });
+      cartTotalEl.textContent = `Total: ₱${total.toFixed(2)}`;
+      cartCountEl.textContent = `${count} item${count === 1 ? '' : 's'} selected`;
+      const allChecked = items.length && items.every(item => item.querySelector('.item-check').checked);
+      selectAllCheckbox.checked = allChecked;
+      confirmBtn.disabled = count === 0;
+    }
+
+    async function adjustQuantity(element, delta) {
+      const display = element.querySelector('.qty-display');
+      let qty = parseInt(display.textContent, 10);
+      const newQty = qty + delta;
+      if (newQty < 1) return;
+      const cartItemId = element.dataset.id;
+      display.textContent = newQty;
+      try {
+        await fetch('../PHP/cart_api.php?action=update', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `cart_item_id=${encodeURIComponent(cartItemId)}&quantity=${encodeURIComponent(newQty)}`
+        });
+        updateTotals();
+      } catch (err) {
+        console.error('Failed to update quantity:', err);
+        loadCart();
+      }
+    }
+
+    async function removeItem(element) {
+      const cartItemId = element.dataset.id;
+      try {
+        await fetch('../PHP/cart_api.php?action=remove', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `cart_item_id=${encodeURIComponent(cartItemId)}`
+        });
+        element.remove();
+        updateTotals();
+        if (!cartItemsContainer.children.length) {
+          confirmBtn.disabled = true;
+          cartItemsContainer.innerHTML = '<p style="text-align:center;">Your cart is empty.</p>';
+        }
+      } catch (err) {
+        console.error('Failed to remove item:', err);
+        loadCart();
+      }
+    }
+
+    async function loadCart() {
+      if (!userEmail) return;
+      try {
+        const res = await fetch(`../PHP/cart_api.php?action=list&email=${encodeURIComponent(userEmail)}`);
+        if (!res.ok) {
+          throw new Error('Unable to load cart items.');
+        }
+        const data = await res.json();
+        currentCart = data.items || [];
+        cartItemsContainer.innerHTML = '';
+        if (!currentCart.length) {
+          cartItemsContainer.innerHTML = '<p style="text-align:center;">Your cart is empty.</p>';
+          confirmBtn.disabled = true;
+          cartTotalEl.textContent = 'Total: ₱0.00';
+          cartCountEl.textContent = '0 items selected';
+          return;
+        }
+        currentCart.forEach(item => {
+          cartItemsContainer.appendChild(createCartItemElement(item));
+        });
+        updateTotals();
+      } catch (err) {
+        console.error(err);
+        cartItemsContainer.innerHTML = '<p style="text-align:center;">Failed to load cart. Please refresh.</p>';
+        confirmBtn.disabled = true;
+      }
+    }
+
+    async function loadProfile() {
+      if (!userEmail) return;
+      try {
+        const res = await fetch(`../PHP/user_api.php?action=get_profile&email=${encodeURIComponent(userEmail)}`);
+        if (!res.ok) {
+          throw new Error('Unable to load profile.');
+        }
+        const data = await res.json();
+        currentProfile = {
+          name: data.name || '',
+          address: data.address || ''
+        };
+        if (!nameInput.value) nameInput.value = currentProfile.name || '';
+        if (!addressInput.value) addressInput.value = currentProfile.address || '';
+        phoneInput.value = loadStoredPhone(userEmail) || '';
+      } catch (err) {
+        console.error(err);
+        currentProfile = { name: '', address: '' };
+      }
+    }
+
+    async function placeOrder() {
+      setMessage('');
+      const name = nameInput.value.trim();
+      const phone = phoneInput.value.trim();
+      const orderType = orderTypeSelect.value;
+      const payment = paymentSelect.value;
+      const address = addressInput.value.trim();
+      const notes = notesInput.value.trim();
+
+      if (!name) {
+        setMessage('Please enter your full name.');
+        return;
+      }
+      if (phone && !/^09\d{9}$/.test(phone)) {
+        setMessage('Please provide a valid phone number (09xxxxxxxxx).');
+        return;
+      }
+      if (!orderType) {
+        setMessage('Please choose an order type.');
+        return;
+      }
+      if (!payment) {
+        setMessage('Please select a payment method.');
+        return;
+      }
+      if (orderType === 'Delivery' && !address) {
+        setMessage('Please provide a delivery address.');
+        return;
       }
 
-      const summaryItems = document.getElementById('summaryItems');
-      summaryItems.innerHTML = "";
-      let total = 0;
-      cart.forEach(item => {
-        total += item.price * item.qty;
-        const li = document.createElement('li');
-        li.textContent = `${item.qty} × ${item.name} - ₱${item.price * item.qty}`;
-        summaryItems.appendChild(li);
-      });
-      document.getElementById('summaryTotal').textContent = `Total: ₱${total}`;
-      document.getElementById('summaryTime').textContent =
-        orderType.value === "delivery" ? "30-45 minutes" : "15-20 minutes";
+      const selectedItems = Array.from(document.querySelectorAll('.cart-item')).filter(item => item.querySelector('.item-check').checked);
+      if (!selectedItems.length) {
+        setMessage('Please select at least one item to order.');
+        return;
+      }
 
-      document.getElementById("popup").style.display = "flex";
-      localStorage.removeItem('cartData');
+      const itemsPayload = selectedItems.map(item => ({
+        product_id: item.dataset.product,
+        quantity: parseInt(item.querySelector('.qty-display').textContent, 10)
+      }));
+
+      saveStoredPhone(userEmail, phone);
+
+      try {
+        const profileRes = await fetch('../PHP/user_api.php?action=set_profile', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `email=${encodeURIComponent(userEmail)}&name=${encodeURIComponent(name)}&address=${encodeURIComponent(address)}`
+        });
+        if (!profileRes.ok) {
+          console.warn('Failed to save profile details.');
+        }
+      } catch (err) {
+        console.warn('Error saving profile details:', err);
+      }
+
+      try {
+        const res = await fetch(`../PHP/cart_api.php?action=list&email=${encodeURIComponent(userEmail)}`);
+        const latest = await res.json();
+        const shortages = [];
+        (latest.items || []).forEach(it => {
+          const selected = itemsPayload.find(sel => sel.product_id == it.Product_ID);
+          if (selected && selected.quantity > parseInt(it.Stock_Quantity, 10)) {
+            shortages.push({
+              id: it.Cart_Item_ID,
+              name: it.Name,
+              stock: parseInt(it.Stock_Quantity, 10)
+            });
+          }
+        });
+        if (shortages.length) {
+          await Promise.all(shortages.map(s => fetch('../PHP/cart_api.php?action=update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: `cart_item_id=${encodeURIComponent(s.id)}&quantity=${encodeURIComponent(s.stock)}`
+          })));
+          setMessage(shortages.map(s => `${s.name} quantity adjusted to ${s.stock}. Please review your cart.`).join('\n'));
+          await loadCart();
+          return;
+        }
+      } catch (err) {
+        console.error('Failed stock verification:', err);
+        setMessage('Unable to verify stock levels. Please try again.');
+        return;
+      }
+
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = 'Placing order…';
+
+      try {
+        const orderRes = await fetch('../PHP/order_api.php?action=create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `email=${encodeURIComponent(userEmail)}&items=${encodeURIComponent(JSON.stringify(itemsPayload))}&order_type=${encodeURIComponent(orderType)}&mop=${encodeURIComponent(payment)}`
+        });
+        const orderData = await orderRes.json();
+        if (!orderRes.ok || orderData.error) {
+          throw new Error(orderData.error || 'Unable to place order.');
+        }
+
+        summaryName.textContent = name;
+        summaryPhone.textContent = phone || 'Not provided';
+        summaryType.textContent = orderType;
+        summaryPayment.textContent = payment;
+        summaryNotes.textContent = notes || 'None';
+        if (orderType === 'Delivery' && address) {
+          summaryAddressWrap.style.display = 'block';
+          summaryAddress.textContent = address;
+        } else {
+          summaryAddressWrap.style.display = 'none';
+        }
+
+        summaryItems.innerHTML = '';
+        let total = 0;
+        selectedItems.forEach(item => {
+          const qty = parseInt(item.querySelector('.qty-display').textContent, 10);
+          const price = parseFloat(item.dataset.price);
+          total += price * qty;
+          const li = document.createElement('li');
+          li.textContent = `${qty} × ${item.querySelector('.item-name').textContent} — ₱${(price * qty).toFixed(2)}`;
+          summaryItems.appendChild(li);
+        });
+        summaryTotal.textContent = `Total: ₱${total.toFixed(2)}`;
+        const orderId = orderData.order_id;
+        summaryLink.innerHTML = orderId ? `<a href="../userSide/INVOICE/orderDetails.php?order_id=${orderId}" target="_blank" rel="noopener" style="color:#8B4513;font-weight:600;">View order details</a>` : '';
+
+        summaryPopup.style.display = 'flex';
+        setMessage('Order placed successfully!', 'success');
+        notesInput.value = '';
+        await loadCart();
+      } catch (err) {
+        console.error('Order failed:', err);
+        setMessage(err.message || 'Unable to place order. Please try again.');
+      } finally {
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = '✅ Place Order';
+      }
+    }
+
+    confirmBtn.addEventListener('click', placeOrder);
+
+    onAuthStateChanged(auth, user => {
+      if (user && user.email) {
+        userEmail = user.email;
+        loadProfile();
+        loadCart();
+      } else {
+        window.location.href = 'login.html';
+      }
     });
-
-    function closePopup() { document.getElementById("popup").style.display = "none"; window.location.href = "index.html"; }
-
-    renderCart();
   </script>
 </body>
 </html>

--- a/UserSide-design/home.html
+++ b/UserSide-design/home.html
@@ -365,7 +365,7 @@
       <nav id="navMenu">
         <ul>
           <li><a href="home.html">Home</a></li>
-          <li><a href="login">Login</a></li>
+          <li><a href="login.html">Login</a></li>
           <li><a href="#about">About</a></li>
           <li><a href="#visit">Contacts</a></li>
           <li>

--- a/UserSide-design/login.html
+++ b/UserSide-design/login.html
@@ -61,23 +61,23 @@ nav ul li a:hover {
 }
 
 /* Main Login Box */
-.main { 
-  position:relative; 
-  z-index:2; 
-  flex:1; 
-  display:flex; 
-  justify-content:center; 
-  align-items:center; 
-  padding:2rem; 
+.main {
+  position:relative;
+  z-index:2;
+  flex:1;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  padding:2rem;
 }
 
-.login-box { 
-  background:rgba(255,255,255,0.98); 
-  padding:2.5rem; 
-  border-radius:12px; 
-  box-shadow:0 6px 20px rgba(0,0,0,0.2); 
-  max-width:400px; 
-  width:100%; 
+.login-box {
+  background:rgba(255,255,255,0.98);
+  padding:2.5rem;
+  border-radius:12px;
+  box-shadow:0 6px 20px rgba(0,0,0,0.2);
+  max-width:400px;
+  width:100%;
   display:flex;
   flex-direction:column;
   gap:16px;
@@ -86,11 +86,11 @@ nav ul li a:hover {
 .login-box h2 { color:#d62828; text-align:center; margin-bottom:1rem; font-size:1.5rem; }
 
 .input-group { position:relative; display:flex; flex-direction:column; gap:6px; }
-.input-group input { 
-  padding:12px; 
-  border-radius:8px; 
-  border:1px solid #ccc; 
-  font-size:1rem; 
+.input-group input {
+  padding:12px;
+  border-radius:8px;
+  border:1px solid #ccc;
+  font-size:1rem;
   width:100%;
   transition: border-color 0.2s;
 }
@@ -118,21 +118,32 @@ nav ul li a:hover {
 }
 .eye-icon:hover { fill:#d62828; }
 
-.login-box button { 
-  width:100%; 
-  padding:12px; 
-  background:#d62828; 
-  color:#fff; 
-  border:none; 
-  border-radius:8px; 
-  font-weight:700; 
-  cursor:pointer; 
+.login-box button {
+  width:100%;
+  padding:12px;
+  background:#d62828;
+  color:#fff;
+  border:none;
+  border-radius:8px;
+  font-weight:700;
+  cursor:pointer;
   font-size:1rem;
   margin-top:8px;
 }
+.login-box button:disabled {
+  opacity:0.7;
+  cursor:not-allowed;
+}
 
-.note { font-size:0.85rem; color:#666; margin-top:12px; text-align:center; }
+.note { font-size:0.85rem; color:#666; text-align:center; }
 .note a { color:#d62828; font-weight:600; text-decoration:none; }
+
+#errorMessage {
+  color:#d62828;
+  font-size:0.85rem;
+  text-align:center;
+  min-height:1.2rem;
+}
 
 /* Responsive Hamburger Menu */
 @media (max-width: 768px) {
@@ -169,7 +180,7 @@ nav ul li a:hover {
       <li><a href="login.html" class="active">Login</a></li>
       <li><a href="home.html#about">About</a></li>
       <li><a href="home.html#visit">Contacts</a></li>
-      <li><a href="signup.html">Signup</a></li>
+      <li><a href="SignupPage.html">Signup</a></li>
     </ul>
   </nav>
 </header>
@@ -177,7 +188,7 @@ nav ul li a:hover {
 <div class="main">
   <div class="login-box">
     <h2>Login</h2>
-    <form id="loginForm" action="login-process.php" method="post">
+    <form id="loginForm" novalidate>
       <div class="input-group">
         <label for="email">Email</label>
         <input id="email" name="email" type="email" placeholder="Enter your email" required>
@@ -193,10 +204,11 @@ nav ul li a:hover {
         </div>
       </div>
 
+      <div id="errorMessage"></div>
       <button type="submit">Login</button>
     </form>
     <div class="note">
-      Don't have an account? <a href="signup.html">Sign up</a>
+      Don't have an account? <a href="SignupPage.html">Sign up</a>
     </div>
   </div>
 </div>
@@ -214,6 +226,68 @@ eyeIcon.addEventListener("click", () => {
 function toggleMenu() {
   document.getElementById("navMenu").classList.toggle("active");
 }
+</script>
+
+<script type="module">
+import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { getAuth, signInWithEmailAndPassword, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+
+const form = document.getElementById('loginForm');
+const submitBtn = form.querySelector('button[type="submit"]');
+const errorBox = document.getElementById('errorMessage');
+
+async function ensureFirebase() {
+  if (!getApps().length) {
+    const configUrl = new URL('../PHP/firebase_config.php', import.meta.url);
+    const response = await fetch(configUrl, { credentials: 'same-origin' });
+    if (!response.ok) {
+      throw new Error(`Unable to load Firebase configuration: ${response.status}`);
+    }
+    const config = await response.json();
+    initializeApp(config);
+  }
+  return getAuth();
+}
+
+function setLoading(isLoading) {
+  submitBtn.disabled = isLoading;
+  submitBtn.textContent = isLoading ? 'Signing in…' : 'Login';
+}
+
+ensureFirebase()
+  .then(auth => {
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        window.location.href = 'Menu.html';
+      }
+    });
+
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      errorBox.textContent = '';
+      const email = form.email.value.trim();
+      const password = form.password.value;
+      if (!email || !password) {
+        errorBox.textContent = 'Please enter your email and password.';
+        return;
+      }
+      setLoading(true);
+      signInWithEmailAndPassword(auth, email, password)
+        .then(() => {
+          // onAuthStateChanged will handle redirect
+        })
+        .catch(err => {
+          console.error('Login failed:', err);
+          errorBox.textContent = err.message || 'Unable to sign in. Please try again.';
+          setLoading(false);
+        });
+    });
+  })
+  .catch(err => {
+    console.error('Firebase init failed:', err);
+    errorBox.textContent = 'Unable to connect to authentication service. Please try again later.';
+    submitBtn.disabled = true;
+  });
 </script>
 
 </body>

--- a/UserSide-design/orders.html
+++ b/UserSide-design/orders.html
@@ -6,34 +6,36 @@
   <title>Cindy's Bakery — Order History</title>
   <style>
     body {
-      font-family: Arial, sans-serif;
+      font-family: 'Poppins', sans-serif;
       background: #f7f7f7;
       margin: 0;
       padding: 0;
+      color:#333;
     }
     header {
       display: flex;
       align-items: center;
-      background: #ff6a00;
+      background: #8B4513;
       color: white;
-      padding: 12px 16px;
+      padding: 16px 20px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+      justify-content: space-between;
+      flex-wrap:wrap;
     }
-    header button {
-      background: white;
-      color: #ff6a00;
-      border: none;
-      padding: 6px 12px;
-      border-radius: 6px;
-      cursor: pointer;
-      font-size: 14px;
-      margin-right: 10px;
+    header .logo {
+      font-weight:600;
+      font-size:1.1rem;
     }
-    header h1 {
-      font-size: 18px;
-      margin: 0;
-      flex: 1;
-      text-align: center;
+    header nav a {
+      color:#fff;
+      text-decoration:none;
+      margin-left:1rem;
+      font-weight:500;
+      padding:0.4rem 0.8rem;
+      border-radius:999px;
+    }
+    header nav a:hover, header nav a.active {
+      background:rgba(255,255,255,0.25);
     }
     .tabs {
       display: flex;
@@ -53,49 +55,54 @@
       transition: all 0.2s ease;
     }
     .tab.active {
-      background: #ff6a00;
+      background: #8B4513;
       color: white;
-      border-color: #ff6a00;
+      border-color: #8B4513;
     }
     .orders {
-      max-width: 700px;
+      max-width: 900px;
       margin: 0 auto;
       display: flex;
       flex-direction: column;
       gap: 15px;
-      padding: 0 15px 20px;
+      padding: 0 15px 40px;
     }
     .order-card {
       background: #fff;
-      border-radius: 12px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-      padding: 15px;
+      border-radius: 16px;
+      box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+      padding: 18px;
     }
     .order-header {
       display: flex;
       justify-content: space-between;
-      margin-bottom: 10px;
+      margin-bottom: 12px;
       font-size: 14px;
       color: #666;
+      flex-wrap:wrap;
+      gap:0.5rem;
     }
     .order-items {
       display: flex;
       align-items: center;
-      gap: 12px;
-      margin-bottom: 10px;
+      gap: 14px;
+      margin-bottom: 12px;
+      flex-wrap:wrap;
     }
     .order-items img {
-      width: 70px;
-      height: 70px;
+      width: 90px;
+      height: 90px;
       object-fit: cover;
-      border-radius: 8px;
+      border-radius: 12px;
+      border:1px solid #f1e2d3;
     }
     .item-info {
       flex: 1;
+      min-width:180px;
     }
     .item-info h3 {
       margin: 0;
-      font-size: 15px;
+      font-size: 16px;
       color: #333;
     }
     .item-info p {
@@ -107,29 +114,51 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      flex-wrap:wrap;
+      gap:0.6rem;
     }
     .status {
       font-size: 13px;
       font-weight: bold;
+      padding:0.3rem 0.8rem;
+      border-radius:999px;
+      background:#f5ede5;
+      color:#8B4513;
     }
-    .status.completed { color: green; }
-    .status.cancelled { color: red; }
-    .status.pending { color: #ff6a00; }
+    .status.completed { background:#e6f4ea; color:#1b5e20; }
+    .status.cancelled { background:#fdecea; color:#b3261e; }
+    .status.pending { background:#fff4e5; color:#c26516; }
     .total {
       font-weight: bold;
       font-size: 15px;
       color: #111;
     }
+    .details-link {
+      text-decoration:none;
+      color:#8B4513;
+      font-weight:600;
+    }
+    .info-text {
+      text-align:center;
+      color:#b3261e;
+      font-size:0.9rem;
+      min-height:1.2rem;
+      margin-bottom:1.5rem;
+    }
   </style>
 </head>
 <body>
-  <!-- Header -->
   <header>
-    <button onclick="history.back()">← Back</button>
-    <h1>Order History</h1>
+    <div class="logo">🍞 Cindy’s Bakeshop</div>
+    <nav>
+      <a href="home.html">Home</a>
+      <a href="Menu.html">Menu</a>
+      <a href="checkout.html">Cart</a>
+      <a href="orders.html" class="active">Orders</a>
+      <a href="profile.html">Profile</a>
+    </nav>
   </header>
 
-  <!-- Tabs -->
   <div class="tabs">
     <div class="tab active" data-filter="all">All</div>
     <div class="tab" data-filter="topay">To Pay</div>
@@ -138,86 +167,145 @@
     <div class="tab" data-filter="completed">Completed</div>
   </div>
 
-  <!-- Orders -->
-  <div class="orders">
-    <!-- Order 1 -->
-    <div class="order-card" data-status="completed">
-      <div class="order-header">
-        <span>Order #1025</span>
-        <span>Sept 11, 2025</span>
-      </div>
-      <div class="order-items">
-        <img src="https://via.placeholder.com/70x70.png?text=Cake" alt="Chocolate Cake">
-        <div class="item-info">
-          <h3>Chocolate Cake</h3>
-          <p>1x, Paid with GCash</p>
-        </div>
-      </div>
-      <div class="order-footer">
-        <span class="status completed">✔ Completed</span>
-        <span class="total">₱820.00</span>
-      </div>
-    </div>
+  <div class="info-text" id="ordersMessage"></div>
+  <div class="orders" id="ordersContainer"></div>
 
-    <!-- Order 2 -->
-    <div class="order-card" data-status="toreceive">
-      <div class="order-header">
-        <span>Order #1024</span>
-        <span>Sept 09, 2025</span>
-      </div>
-      <div class="order-items">
-        <img src="https://via.placeholder.com/70x70.png?text=Pandesal" alt="Pandesal Pack">
-        <div class="item-info">
-          <h3>Pandesal Pack (5x)</h3>
-          <p>Cash on Pickup</p>
-        </div>
-      </div>
-      <div class="order-footer">
-        <span class="status pending">To Receive</span>
-        <span class="total">₱250.00</span>
-      </div>
-    </div>
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../userSide/firebase-init.js";
 
-    <!-- Order 3 -->
-    <div class="order-card" data-status="toprepare">
-      <div class="order-header">
-        <span>Order #1023</span>
-        <span>Sept 08, 2025</span>
-      </div>
-      <div class="order-items">
-        <img src="https://via.placeholder.com/70x70.png?text=Tapsilog" alt="Tapsilog Meal">
-        <div class="item-info">
-          <h3>Tapsilog Meal</h3>
-          <p>2x, Cash</p>
-        </div>
-      </div>
-      <div class="order-footer">
-        <span class="status pending">To Prepare</span>
-        <span class="total">₱450.00</span>
-      </div>
-    </div>
-  </div>
+    const ordersContainer = document.getElementById('ordersContainer');
+    const tabs = document.querySelectorAll('.tab');
+    const ordersMessage = document.getElementById('ordersMessage');
 
-  <script>
-    const tabs = document.querySelectorAll(".tab");
-    const orders = document.querySelectorAll(".order-card");
+    const auth = getAuth();
+    let userEmail = null;
+    let ordersData = [];
+    let activeFilter = 'all';
+
+    function setMessage(text, type = 'error') {
+      ordersMessage.textContent = text || '';
+      ordersMessage.style.color = type === 'error' ? '#b3261e' : '#1b5e20';
+    }
+
+    function mapStatus(status) {
+      const value = (status || '').toLowerCase();
+      if (['pending', 'awaiting payment', 'to pay'].includes(value)) return 'topay';
+      if (['processing', 'to prepare', 'preparing'].includes(value)) return 'toprepare';
+      if (['to receive', 'for delivery', 'shipped', 'out for delivery'].includes(value)) return 'toreceive';
+      if (['completed', 'delivered', 'finished'].includes(value)) return 'completed';
+      if (['cancelled', 'canceled'].includes(value)) return 'cancelled';
+      return 'other';
+    }
+
+    function statusClass(statusKey) {
+      switch (statusKey) {
+        case 'completed': return 'status completed';
+        case 'cancelled': return 'status cancelled';
+        case 'topay':
+        case 'toprepare':
+        case 'toreceive':
+          return 'status pending';
+        default: return 'status';
+      }
+    }
+
+    function formatDate(value) {
+      if (!value) return '';
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return value;
+      return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+
+    function renderOrders(filter) {
+      activeFilter = filter;
+      ordersContainer.innerHTML = '';
+      const filtered = ordersData.filter(order => filter === 'all' || mapStatus(order.Status) === filter);
+      if (!filtered.length) {
+        setMessage('No orders found for this category.', 'error');
+        return;
+      }
+      setMessage('');
+      filtered.forEach(order => {
+        const statusKey = mapStatus(order.Status);
+        const card = document.createElement('div');
+        card.className = 'order-card';
+        card.dataset.status = statusKey;
+
+        const detail = order.detail || {};
+        const items = (detail.items || []).map(item => `${item.Quantity} × ${item.Name}`).join(', ');
+        const total = detail.transaction?.Amount_Paid || detail.transaction?.Total_Amount || detail.order?.Total_Amount || null;
+        const amountText = total ? `₱${parseFloat(total).toFixed(2)}` : (order.Total ? `₱${parseFloat(order.Total).toFixed(2)}` : '');
+        const imagePath = order.Image_Path ? `../adminSide/products/uploads/${order.Image_Path}` : '../userSide/Images/cindy_s logo.png';
+
+        card.innerHTML = `
+          <div class="order-header">
+            <span>Order #${order.Order_ID}</span>
+            <span>${formatDate(order.Order_Date)}</span>
+          </div>
+          <div class="order-items">
+            <img src="${imagePath}" alt="Order ${order.Order_ID}">
+            <div class="item-info">
+              <h3>${items || 'Items in this order'}</h3>
+              <p>Status: ${order.Status || 'N/A'}</p>
+            </div>
+          </div>
+          <div class="order-footer">
+            <span class="${statusClass(statusKey)}">${order.Status || 'Unknown'}</span>
+            <span class="total">${amountText || ''}</span>
+            <a class="details-link" href="../userSide/INVOICE/orderDetails.php?order_id=${order.Order_ID}" target="_blank" rel="noopener">View Details</a>
+          </div>
+        `;
+        ordersContainer.appendChild(card);
+      });
+    }
 
     tabs.forEach(tab => {
-      tab.addEventListener("click", () => {
-        // Reset active tab
-        tabs.forEach(t => t.classList.remove("active"));
-        tab.classList.add("active");
-
-        const filter = tab.dataset.filter;
-
-        orders.forEach(order => {
-          if (filter === "all" || order.dataset.status === filter) {
-            order.style.display = "block";
-          } else {
-            order.style.display = "none";
-          }
-        });
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        renderOrders(tab.dataset.filter);
       });
+    });
+
+    async function loadOrders() {
+      if (!userEmail) return;
+      setMessage('Loading orders…', 'success');
+      try {
+        const res = await fetch(`../PHP/order_api.php?action=list&email=${encodeURIComponent(userEmail)}`);
+        if (!res.ok) {
+          throw new Error('Unable to load orders.');
+        }
+        const orders = await res.json();
+        const detailed = await Promise.all(orders.map(async order => {
+          try {
+            const detailRes = await fetch(`../PHP/order_api.php?action=view&order_id=${encodeURIComponent(order.Order_ID)}`);
+            if (!detailRes.ok) {
+              throw new Error('');
+            }
+            const detailData = await detailRes.json();
+            return { ...order, detail: detailData };
+          } catch (err) {
+            console.warn('Failed to load order details for', order.Order_ID, err);
+            return { ...order, detail: null };
+          }
+        }));
+        ordersData = detailed;
+        renderOrders(activeFilter);
+      } catch (err) {
+        console.error(err);
+        ordersData = [];
+        setMessage('Failed to load your orders. Please refresh the page.', 'error');
+      }
+    }
+
+    onAuthStateChanged(auth, user => {
+      if (user && user.email) {
+        userEmail = user.email;
+        loadOrders();
+      } else {
+        window.location.href = 'login.html';
+      }
     });
   </script>
 </body>

--- a/UserSide-design/profile.html
+++ b/UserSide-design/profile.html
@@ -9,152 +9,288 @@
     *{margin:0;padding:0;box-sizing:border-box;font-family:"Poppins",sans-serif;}
     body{background:#faf9f7;color:#333;}
 
-    nav{background:#8b4513;color:#fff;display:flex;justify-content:space-between;align-items:center;padding:1rem 2rem;}
+    nav{background:#8b4513;color:#fff;display:flex;justify-content:space-between;align-items:center;padding:1rem 2rem;flex-wrap:wrap;}
     nav .logo{font-size:1.4rem;font-weight:600;}
-    nav ul{list-style:none;display:flex;gap:1.5rem;align-items:center;}
-    nav ul li a{color:#fff;text-decoration:none;font-weight:500;}
-    nav ul li a:hover{text-decoration:underline;}
+    nav ul{list-style:none;display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap;}
+    nav ul li a{color:#fff;text-decoration:none;font-weight:500;padding:0.4rem 0.8rem;border-radius:999px;}
+    nav ul li a:hover,nav ul li a.active{background:rgba(255,255,255,0.2);}
 
-    .profile-container{max-width:600px;margin:2rem auto;background:#fff;padding:2rem;border-radius:12px;box-shadow:0 3px 10px rgba(0,0,0,0.1);text-align:center;}
-    .profile-container h2{color:#8b4513;margin-bottom:1rem;}
+    .profile-container{max-width:650px;margin:2rem auto;background:#fff;padding:2.5rem 2rem;border-radius:16px;box-shadow:0 3px 12px rgba(0,0,0,0.12);text-align:center;}
+    .profile-container h2{color:#8b4513;margin-bottom:1.5rem;letter-spacing:1px;}
 
-    .profile-pic{
-      width:120px;
-      height:120px;
-      border-radius:50%;
-      object-fit:cover;
-      margin-bottom:1rem;
-      border:3px solid #8b4513;
-      cursor:pointer;
-      transition:0.3s;
-    }
-    .profile-pic:hover{opacity:0.8;}
+    .profile-pic{width:140px;height:140px;border-radius:50%;object-fit:cover;margin:0 auto 1rem;border:4px solid #8b4513;transition:0.3s;cursor:pointer;background:#f4e8dc;display:block;}
+    .profile-pic:hover{opacity:0.85;}
 
-    .profile-view p{margin:0.8rem 0;font-size:1rem;text-align:left;}
-    .profile-view span{font-weight:600;color:#8b4513;}
+    .profile-view{display:flex;flex-direction:column;gap:0.6rem;text-align:left;}
+    .profile-view p{margin:0;font-size:1rem;display:flex;justify-content:space-between;gap:0.8rem;}
+    .profile-view span.label{font-weight:600;color:#8b4513;min-width:120px;}
 
-    .btn{margin-top:1.5rem;background:#8b4513;color:#fff;border:none;padding:0.8rem 1.5rem;border-radius:8px;cursor:pointer;font-weight:600;width:100%;}
+    .btn{margin-top:1.5rem;background:#8b4513;color:#fff;border:none;padding:0.9rem 1.5rem;border-radius:10px;cursor:pointer;font-weight:600;width:100%;transition:0.2s;}
     .btn:hover{background:#a0522d;}
+    .btn:disabled{opacity:0.7;cursor:not-allowed;}
 
-    .profile-form{display:none;text-align:left;}
-    .profile-form label{display:block;font-weight:600;margin-top:1rem;}
-    .profile-form input,.profile-form textarea{width:100%;padding:0.7rem;border:1px solid #ddd;border-radius:8px;margin-top:0.3rem;font-size:1rem;}
-    .profile-form textarea{resize:none;height:80px;}
+    .profile-form{text-align:left;margin-top:1.5rem;display:none;}
+    .profile-form label{display:block;font-weight:600;margin-top:1rem;color:#8b4513;}
+    .profile-form input,.profile-form textarea{width:100%;padding:0.75rem;border:1px solid #ddd;border-radius:10px;margin-top:0.4rem;font-size:1rem;}
+    .profile-form textarea{resize:none;height:90px;}
 
-    /* Hide file input */
-    #picUpload{display:none;}
+    #profileMessage{margin-top:1rem;font-size:0.9rem;min-height:1.2rem;text-align:center;}
+    #profileMessage.error{color:#b3261e;}
+    #profileMessage.success{color:#1b5e20;}
 
     footer{text-align:center;padding:1.5rem;background:#8b4513;color:#fff;margin-top:2rem;font-size:0.9rem;}
   </style>
 </head>
 <body>
-  <!-- Navbar -->
   <nav>
     <div class="logo">🍞 Cindy’s Bakeshop</div>
     <ul>
-      <li><a href="index.html">Home</a></li>
-      <li><a href="checkout.html">Cart 🛒</a></li>
+      <li><a href="home.html">Home</a></li>
+      <li><a href="Menu.html">Menu</a></li>
+      <li><a href="checkout.html">Cart</a></li>
+      <li><a href="orders.html">Orders</a></li>
+      <li><a href="profile.html" class="active">Profile</a></li>
+      <li><a href="../userSide/LOGIN_SIGNUP/logout.html">Logout</a></li>
     </ul>
   </nav>
 
-  <!-- Profile Section -->
   <div class="profile-container">
     <h2>My Profile</h2>
 
-    <!-- Profile view (default) -->
+    <img src="https://via.placeholder.com/140?text=Profile" alt="Profile Picture" id="profilePic" class="profile-pic"/>
+
     <div class="profile-view" id="profileView">
-      <img src="https://via.placeholder.com/120" alt="Profile Picture" id="profilePic" class="profile-pic"/>
-      <p><span>Full Name:</span> Juan Dela Cruz</p>
-      <p><span>Email:</span> juan@email.com</p>
-      <p><span>Phone:</span> 09123456789</p>
-      <p><span>Address:</span> 123 Street, Barangay, City</p>
+      <p><span class="label">Full Name:</span> <span id="viewName">Loading…</span></p>
+      <p><span class="label">Email:</span> <span id="viewEmail">Loading…</span></p>
+      <p><span class="label">Phone:</span> <span id="viewPhone">Not set</span></p>
+      <p><span class="label">Address:</span> <span id="viewAddress">Not set</span></p>
       <button class="btn" id="editBtn">Edit Profile</button>
     </div>
 
-    <!-- Edit form (hidden by default) -->
-    <form class="profile-form" id="profileForm">
-      <!-- Hidden file input (triggered by picture click) -->
-      <input type="file" id="picUpload" accept="image/*" capture="environment"/>
-
+    <form class="profile-form" id="profileForm" enctype="multipart/form-data">
       <label for="name">Full Name</label>
-      <input type="text" id="name" value="Juan Dela Cruz" />
+      <input type="text" id="name" required />
 
       <label for="email">Email Address</label>
-      <input type="email" id="email" value="juan@email.com" />
+      <input type="email" id="email" readonly />
 
       <label for="phone">Phone Number</label>
-      <input type="text" id="phone" value="09123456789" />
+      <input type="text" id="phone" placeholder="09xxxxxxxxx" />
 
       <label for="address">Delivery Address</label>
-      <textarea id="address">123 Street, Barangay, City</textarea>
+      <textarea id="address" placeholder="House No., Street, Barangay, City"></textarea>
 
-      <label for="password">Change Password</label>
-      <input type="password" id="password" placeholder="••••••••" />
+      <label for="newPassword">Change Password</label>
+      <input type="password" id="newPassword" placeholder="Leave blank to keep current password" />
+
+      <label for="picUpload">Profile Picture</label>
+      <input type="file" id="picUpload" accept="image/*" />
 
       <button type="button" class="btn" id="saveBtn">Save Changes</button>
     </form>
+
+    <div id="profileMessage"></div>
   </div>
 
   <footer>© 2025 Cindy’s Bakeshop • Freshness Guaranteed</footer>
 
-  <script>
-    const profileView = document.getElementById("profileView");
-    const profileForm = document.getElementById("profileForm");
-    const editBtn = document.getElementById("editBtn");
-    const saveBtn = document.getElementById("saveBtn");
-    const profilePic = document.getElementById("profilePic");
-    const picUpload = document.getElementById("picUpload");
+  <script type="module">
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import "../userSide/firebase-init.js";
 
-    let uploadedImage = profilePic.src; // default image
+    const DEFAULT_AVATAR = "https://via.placeholder.com/140?text=Profile";
+    const profilePic = document.getElementById('profilePic');
+    const profileView = document.getElementById('profileView');
+    const profileForm = document.getElementById('profileForm');
+    const editBtn = document.getElementById('editBtn');
+    const saveBtn = document.getElementById('saveBtn');
+    const messageEl = document.getElementById('profileMessage');
+    const nameInput = document.getElementById('name');
+    const emailInput = document.getElementById('email');
+    const phoneInput = document.getElementById('phone');
+    const addressInput = document.getElementById('address');
+    const passwordInput = document.getElementById('newPassword');
+    const picUpload = document.getElementById('picUpload');
+    const viewName = document.getElementById('viewName');
+    const viewEmail = document.getElementById('viewEmail');
+    const viewPhone = document.getElementById('viewPhone');
+    const viewAddress = document.getElementById('viewAddress');
 
-    // Click profile pic → open file selector (always works)
-    profilePic.addEventListener("click", () => {
-      picUpload.click();
-    });
+    let currentUserEmail = null;
+    let currentProfile = { name: '', address: '', face: null };
 
-    // Preview uploaded picture immediately
-    picUpload.addEventListener("change", (event) => {
-      const file = event.target.files[0];
-      if(file){
+    function setMessage(text, type = '') {
+      messageEl.textContent = text || '';
+      messageEl.classList.toggle('error', type === 'error');
+      messageEl.classList.toggle('success', type === 'success');
+    }
+
+    function resolveImage(path) {
+      if (!path) return DEFAULT_AVATAR;
+      if (path.startsWith('http')) return path;
+      if (path.startsWith('/')) return path;
+      return '/' + path.replace(/^\/+/, '');
+    }
+
+    function updateView(phoneValue) {
+      viewName.textContent = currentProfile.name || 'Not set';
+      viewEmail.textContent = currentUserEmail || 'Not set';
+      viewPhone.textContent = phoneValue || 'Not set';
+      viewAddress.textContent = currentProfile.address || 'Not set';
+      profilePic.src = resolveImage(currentProfile.face);
+    }
+
+    function loadStoredPhone(email) {
+      return localStorage.getItem(`userPhone:${email}`) || '';
+    }
+
+    function saveStoredPhone(email, value) {
+      if (value) {
+        localStorage.setItem(`userPhone:${email}`, value);
+      } else {
+        localStorage.removeItem(`userPhone:${email}`);
+      }
+    }
+
+    async function loadProfile(email) {
+      try {
+        const res = await fetch(`../PHP/user_api.php?action=get_profile&email=${encodeURIComponent(email)}`);
+        if (!res.ok) {
+          throw new Error('Unable to load profile information.');
+        }
+        const data = await res.json();
+        currentProfile = {
+          name: data.name || '',
+          address: data.address || '',
+          face: data.face_image_path || null
+        };
+        const storedPhone = loadStoredPhone(email);
+        updateView(storedPhone);
+      } catch (err) {
+        console.error(err);
+        setMessage('Unable to load profile. Please refresh the page.', 'error');
+        currentProfile = { name: '', address: '', face: null };
+        updateView(loadStoredPhone(email));
+      }
+    }
+
+    function toggleEditMode(showForm) {
+      profileForm.style.display = showForm ? 'block' : 'none';
+      profileView.style.display = showForm ? 'none' : 'flex';
+      messageEl.textContent = '';
+    }
+
+    function prepareForm() {
+      nameInput.value = currentProfile.name || '';
+      emailInput.value = currentUserEmail || '';
+      addressInput.value = currentProfile.address || '';
+      phoneInput.value = loadStoredPhone(currentUserEmail) || '';
+      passwordInput.value = '';
+      picUpload.value = '';
+    }
+
+    async function saveProfile() {
+      if (!currentUserEmail) return;
+      const fullName = nameInput.value.trim();
+      const address = addressInput.value.trim();
+      const phone = phoneInput.value.trim();
+      const password = passwordInput.value;
+      const file = picUpload.files[0];
+
+      if (!fullName) {
+        setMessage('Full name is required.', 'error');
+        return;
+      }
+
+      if (phone && !/^09\d{9}$/.test(phone)) {
+        setMessage('Please enter a valid phone number (09xxxxxxxxx).', 'error');
+        return;
+      }
+
+      const [firstName, ...rest] = fullName.split(/\s+/);
+      const lastName = rest.join(' ');
+
+      const formData = new FormData();
+      formData.append('first_name', firstName || fullName);
+      formData.append('last_name', lastName);
+      formData.append('email', currentUserEmail);
+      formData.append('address', address);
+      if (password) {
+        formData.append('password', password);
+      }
+      if (file) {
+        formData.append('profile_picture', file);
+      }
+
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving…';
+      setMessage('');
+
+      try {
+        const res = await fetch('../PHP/user_api.php?action=update_profile', {
+          method: 'POST',
+          body: formData
+        });
+        const data = await res.json();
+        if (!res.ok || data.error) {
+          throw new Error(data.error || 'Failed to update profile.');
+        }
+        currentProfile.name = fullName;
+        currentProfile.address = address;
+        currentProfile.face = data.face_image_path || currentProfile.face;
+        saveStoredPhone(currentUserEmail, phone);
+        updateView(phone);
+        toggleEditMode(false);
+        setMessage(data.message || 'Profile updated successfully.', 'success');
+      } catch (err) {
+        console.error('Profile update failed:', err);
+        setMessage(err.message || 'Unable to update profile.', 'error');
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save Changes';
+        passwordInput.value = '';
+      }
+    }
+
+    picUpload.addEventListener('change', () => {
+      const file = picUpload.files[0];
+      if (file) {
+        if (file.size > 5 * 1024 * 1024) {
+          setMessage('Profile picture must be 5MB or less.', 'error');
+          picUpload.value = '';
+          return;
+        }
         const reader = new FileReader();
-        reader.onload = (e) => {
-          uploadedImage = e.target.result;
-          profilePic.src = uploadedImage; // update instantly
+        reader.onload = e => {
+          profilePic.src = e.target.result;
         };
         reader.readAsDataURL(file);
+      } else {
+        profilePic.src = resolveImage(currentProfile.face);
       }
     });
 
-    // Switch to edit mode
-    editBtn.addEventListener("click", () => {
-      profileView.style.display = "none";
-      profileForm.style.display = "block";
+    profilePic.addEventListener('click', () => {
+      if (profileForm.style.display === 'block') {
+        picUpload.click();
+      }
     });
 
-    // Save changes
-    saveBtn.addEventListener("click", () => {
-      alert("✅ Your profile has been updated!");
-      profileForm.style.display = "none";
-      profileView.style.display = "block";
+    editBtn.addEventListener('click', () => {
+      prepareForm();
+      toggleEditMode(true);
+    });
 
-      // Update profile view with new values
-      profileView.innerHTML = `
-        <img src="${uploadedImage}" alt="Profile Picture" id="profilePic" class="profile-pic"/>
-        <p><span>Full Name:</span> ${document.getElementById("name").value}</p>
-        <p><span>Email:</span> ${document.getElementById("email").value}</p>
-        <p><span>Phone:</span> ${document.getElementById("phone").value}</p>
-        <p><span>Address:</span> ${document.getElementById("address").value}</p>
-        <button class="btn" id="editBtn">Edit Profile</button>
-      `;
+    saveBtn.addEventListener('click', saveProfile);
 
-      // Reattach event listeners
-      document.getElementById("editBtn").addEventListener("click", () => {
-        profileView.style.display = "none";
-        profileForm.style.display = "block";
-      });
-      document.getElementById("profilePic").addEventListener("click", () => {
-        picUpload.click();
-      });
+    const auth = getAuth();
+    onAuthStateChanged(auth, user => {
+      if (user && user.email) {
+        currentUserEmail = user.email;
+        loadProfile(user.email);
+      } else {
+        window.location.href = 'login.html';
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- wire the redesigned login, signup, and profile pages into Firebase auth, face capture, and the existing profile APIs
- reimplement the checkout experience to load cart data, reuse profile details, and place orders with a confirmation summary
- replace the static order history with live order data and ensure the menu dropdown routes to the existing logout endpoint
- extend the user profile API to persist address updates alongside optional password or avatar changes

## Testing
- php -l PHP/user_api.php

------
https://chatgpt.com/codex/tasks/task_e_68dc541c6e908324a08ebdff95460727